### PR TITLE
feat: apply design system to login and stamp pages

### DIFF
--- a/app/(protected)/nfc/page.tsx
+++ b/app/(protected)/nfc/page.tsx
@@ -37,13 +37,13 @@ export default async function NFCPage({ searchParams }: NFCPageProps) {
     const initialWorkDescription = lastLog?.fields.workDescription ?? '';
 
     return (
-      <main className="flex min-h-screen items-center justify-center bg-gray-100 p-4">
+      <main className="flex min-h-[calc(100vh-61px)] items-center justify-center bg-base p-4">
         <StampCard
           initialStampType={initialStampType}
           initialWorkDescription={initialWorkDescription}
           userName={session.user.name ?? 'ゲスト'}
           // ### 修正点 2: 取得した機械名をStampCardに渡す ###
-          machineName={searchParams.machineid as string}
+          machineName={machine.fields.name}
         />
       </main>
     );

--- a/components/StampCard.tsx
+++ b/components/StampCard.tsx
@@ -38,6 +38,7 @@ export default function StampCard({
 
   const searchParams = useSearchParams();
   const machineId = searchParams.get('machineid');
+  const siteName = searchParams.get('site');
 
   useEffect(() => {
     if (stampType === 'IN') {
@@ -112,6 +113,9 @@ export default function StampCard({
         <div className="rounded-lg bg-white p-6 shadow-md">
             <div className="space-y-2 text-center">
                 <p className="text-lg font-semibold text-gray-800">{userName} さん</p>
+                <p className="text-gray-600">
+                    <span className="font-semibold">現場:</span> {siteName ?? '不明'}
+                </p>
                 <p className="text-gray-600">
                     <span className="font-semibold">機械:</span> {machineName}
                 </p>

--- a/tests/stamp.test.mjs
+++ b/tests/stamp.test.mjs
@@ -6,3 +6,15 @@ test('validateStampRequest fails on missing fields', () => {
   const result = validateStampRequest({});
   assert.strictEqual(result.success, false);
 });
+
+test('validateStampRequest succeeds with valid data', () => {
+  const result = validateStampRequest({
+    machineId: 'm1',
+    workDescription: '作業',
+    lat: 35.0,
+    lon: 139.0,
+    accuracy: 5,
+    type: 'IN',
+  });
+  assert.strictEqual(result.success, true);
+});


### PR DESCRIPTION
## 目的
- unify UI design across login and stamp pages

## 変更点
- add site information card and primary color layout for NFC stamping
- pass machine name and apply base color background
- extend stamp validator tests

## 影響範囲
- `/nfc` page rendering
- `StampCard` component styling
- stamp API validator tests

## ロールバック手順
- `git revert 583926c`

## テスト結果
- `pnpm build` : network error fetching Google Fonts
- `pnpm test` : pass
- `pnpm lint` : pass

------
https://chatgpt.com/codex/tasks/task_e_68be23ae57908329823c792a3df33f9b