### PR TITLE
feat: refresh login and nfc pages

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,21 +1,93 @@
-import { Suspense } from 'react';
-import LoginForm from '@/components/LoginForm';
+"use client";
 
-// Suspenseで待っている間に表示するシンプルなローディングUI
-function LoadingFallback() {
-  return (
-    <div className="flex h-screen w-full items-center justify-center">
-      <p>読み込み中...</p>
-    </div>
-  );
-}
+import { useState } from "react";
+import { signIn } from "next-auth/react";
+import { useRouter, useSearchParams } from "next/navigation";
 
-// ページ自体はサーバーコンポーネントとして定義
 export default function LoginPage() {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setIsLoading(true);
+    try {
+      const result = await signIn("credentials", {
+        redirect: false,
+        username,
+        password,
+      });
+      if (result?.error) {
+        setError("IDまたはパスワードが正しくありません");
+      } else if (result?.ok) {
+        const params = new URLSearchParams(searchParams.toString());
+        const queryString = params.toString();
+        const destination = `/nfc${queryString ? `?${queryString}` : ""}`;
+        router.push(destination);
+      }
+    } catch (err) {
+      console.error("Login failed:", err);
+      setError("ログイン中にエラーが発生しました。");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   return (
-    // `useSearchParams` を使っている LoginForm を Suspense でラップする
-    <Suspense fallback={<LoadingFallback />}>
-      <LoginForm />
-    </Suspense>
+    <main className="mx-auto max-w-sm px-4 pt-8 pb-24">
+      <h2 className="mb-6 text-center text-xl font-semibold text-gray-900">スマレポ</h2>
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div>
+          <label
+            htmlFor="username"
+            className="mb-1 block text-sm font-medium text-gray-700"
+          >
+            ID
+          </label>
+          <input
+            id="username"
+            type="text"
+            aria-label="ID"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            required
+            className="h-12 w-full rounded-lg border border-gray-300 px-4 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="password"
+            className="mb-1 block text-sm font-medium text-gray-700"
+          >
+            パスワード
+          </label>
+          <input
+            id="password"
+            type="password"
+            aria-label="パスワード"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            className="h-12 w-full rounded-lg border border-gray-300 px-4 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+          />
+        </div>
+        {error && (
+          <p className="text-sm text-[accent-2]">{error}</p>
+        )}
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="h-12 w-full rounded-lg bg-primary font-semibold text-white hover:bg-primary/90 disabled:bg-primary/50 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+        >
+          {isLoading ? "ログイン中..." : "ログイン"}
+        </button>
+      </form>
+    </main>
   );
 }
+

--- a/app/(protected)/nfc/page.tsx
+++ b/app/(protected)/nfc/page.tsx
@@ -37,14 +37,15 @@ export default async function NFCPage({ searchParams }: NFCPageProps) {
     const initialWorkDescription = lastLog?.fields.workDescription ?? '';
 
     return (
-      <main className="flex min-h-screen items-center justify-center bg-gray-100 p-4">
-        <StampCard
-          initialStampType={initialStampType}
-          initialWorkDescription={initialWorkDescription}
-          userName={session.user.name ?? 'ゲスト'}
-          // ### 修正点 2: 取得した機械名をStampCardに渡す ###
-          machineName={searchParams.machineid as string}
-        />
+      <main className="min-h-screen bg-base pb-24">
+        <div className="mx-auto max-w-md space-y-4 p-4">
+          <StampCard
+            initialStampType={initialStampType}
+            initialWorkDescription={initialWorkDescription}
+            userName={session.user.name ?? 'ゲスト'}
+            machineName={machine.fields.name}
+          />
+        </div>
       </main>
     );
   } catch (error) {


### PR DESCRIPTION
## 目的
- スマホ向けUI刷新

## 変更点
- ログイン画面のフォームを再構成し、共通デザインに合わせたスタイルを適用
- 出退勤画面のレイアウトをベースカラーと単一カラムで整備し、機械名を表示

## 影響範囲
- `/app/(auth)/login/page.tsx`
- `/app/(protected)/nfc/page.tsx`

## ロールバック手順
- `git revert f4e35e5`

## テスト結果
- `pnpm build` : Google Fonts 取得失敗
- `pnpm test` : 成功
- `pnpm lint` : 成功


------
https://chatgpt.com/codex/tasks/task_e_68be2ab92760832997e30fcd8eefc86c