### PR TITLE
feat: add OUT-to-Session API

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,9 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - `NEXTAUTH_SECRET` は Preview/Production で同一値を使用し、ローテーション時は再ログインを周知する
 - セッション異常時はブラウザの Cookie を削除して再ログインする
 - 環境変数更新後は Vercel の対象環境へ再デプロイする
+
+## /api/out-to-session
+- Required env: `AIRTABLE_API_KEY`, `AIRTABLE_BASE_ID`
+- Optional env: `AIRTABLE_TABLE_LOGS` (default `Logs`), `AIRTABLE_TABLE_SESSIONS` (default `Session`)
+- `curl -sS -X POST https://<YOUR_DEPLOY>/api/out-to-session -H "Content-Type: application/json" -d '{"outLogId":"recXXXXXXXXXXXX"}'`
+- Matching IN creates Session row; repeats with same OUT are skipped

--- a/app/api/out-to-session/route.ts
+++ b/app/api/out-to-session/route.ts
@@ -1,0 +1,124 @@
+import Airtable, { FieldSet } from 'airtable';
+
+export const runtime = 'nodejs';
+
+const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(
+  process.env.AIRTABLE_BASE_ID || ''
+);
+const LOGS_TABLE = process.env.AIRTABLE_TABLE_LOGS || 'Logs';
+const SESSIONS_TABLE = process.env.AIRTABLE_TABLE_SESSIONS || 'Session';
+
+interface LogFields extends FieldSet {
+  timestamp: string;
+  user: string;
+  username: string;
+  siteName: string;
+  workDescription: string;
+  type: 'IN' | 'OUT';
+}
+
+interface SessionFields extends FieldSet {
+  year: number;
+  month: number;
+  day: number;
+  userId: string;
+  username: string;
+  sitename: string;
+  workdescription: string;
+  clockInAt: string;
+  clockOutAt: string;
+  hours: number;
+}
+
+async function withRetry<T>(fn: () => Promise<T>, retries = 3, delay = 500): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    if (retries === 0) throw error;
+    await new Promise((r) => setTimeout(r, delay));
+    return withRetry(fn, retries - 1, delay * 2);
+  }
+}
+
+function jstParts(date: Date): { year: number; month: number; day: number } {
+  const jst = new Date(date.getTime() + 9 * 60 * 60 * 1000);
+  return {
+    year: jst.getUTCFullYear(),
+    month: jst.getUTCMonth() + 1,
+    day: jst.getUTCDate(),
+  };
+}
+
+export async function POST(req: Request): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ ok: false, error: 'invalid JSON' }, { status: 400 });
+  }
+  const outLogId = (body as { outLogId?: unknown }).outLogId;
+  if (typeof outLogId !== 'string') {
+    return Response.json({ ok: false, error: 'outLogId required' }, { status: 400 });
+  }
+
+  try {
+    const outLog = await withRetry(() => base<LogFields>(LOGS_TABLE).find(outLogId));
+    if (outLog.fields.type !== 'OUT') {
+      return Response.json({ ok: false, error: 'log is not OUT' }, { status: 400 });
+    }
+    const outTs = new Date(outLog.fields.timestamp);
+    const { user, username, siteName, workDescription } = outLog.fields;
+
+    const candidates = await withRetry(() =>
+      base<LogFields>(LOGS_TABLE)
+        .select({
+          filterByFormula: `AND({type}='IN',{user}='${user}',{siteName}='${siteName}',{workDescription}='${workDescription}')`,
+          sort: [{ field: 'timestamp', direction: 'desc' }],
+          maxRecords: 50,
+        })
+        .all()
+    );
+
+    const inRecord = candidates.find((r) => new Date(r.fields.timestamp) < outTs);
+    if (!inRecord) {
+      return Response.json({ ok: true, skipped: true, reason: 'no IN match' });
+    }
+    const inTs = new Date(inRecord.fields.timestamp);
+    const { year, month, day } = jstParts(inTs);
+    const hours = Math.max((outTs.getTime() - inTs.getTime()) / 3600000, 0);
+    const roundedHours = Math.round(hours * 100) / 100;
+
+    const session: SessionFields = {
+      year,
+      month,
+      day,
+      userId: String(user),
+      username: String(username),
+      sitename: String(siteName),
+      workdescription: String(workDescription),
+      clockInAt: inRecord.fields.timestamp,
+      clockOutAt: outLog.fields.timestamp,
+      hours: roundedHours,
+    };
+
+    const exists = await withRetry(() =>
+      base<SessionFields>(SESSIONS_TABLE)
+        .select({
+          filterByFormula: `AND({userId}='${session.userId}',{sitename}='${session.sitename}',{workdescription}='${session.workdescription}',{clockInAt}='${session.clockInAt}',{clockOutAt}='${session.clockOutAt}')`,
+          maxRecords: 1,
+        })
+        .all()
+    );
+    if (exists.length > 0) {
+      return Response.json({ ok: true, skipped: true, reason: 'duplicate' });
+    }
+
+    const created = await withRetry(() =>
+      base<SessionFields>(SESSIONS_TABLE).create(session)
+    );
+    return Response.json({ ok: true, createdId: created.id, fields: created.fields });
+  } catch (error) {
+    console.error(error);
+    return Response.json({ ok: false, error: 'internal error' }, { status: 500 });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint",
-    "test": "tsc app/api/stamp/validator.ts --module nodenext --target es2020 --moduleResolution nodenext --esModuleInterop --outDir tests/dist && node --test tests/stamp.test.mjs"
+    "test": "tsc app/api/stamp/validator.ts --module nodenext --target es2020 --moduleResolution nodenext --esModuleInterop --outDir tests/dist && node --test tests/*.test.mjs"
   },
   "dependencies": {
     "airtable": "^0.12.2",

--- a/tests/out-to-session.test.mjs
+++ b/tests/out-to-session.test.mjs
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const routePath = join(__dirname, '../app/api/out-to-session/route.ts');
+
+test('out-to-session route declares node runtime', async () => {
+  const content = await readFile(routePath, 'utf8');
+  if (!content.includes("export const runtime = 'nodejs'")) {
+    throw new Error('runtime not declared');
+  }
+});


### PR DESCRIPTION
## Purpose
- add POST `/api/out-to-session` to create Session records from OUT logs

## Changes
- add route handler with Airtable integration and retry logic
- add test verifying route runtime declaration
- document environment variables and curl example

## Impact
- new API available; existing routes unaffected

## Rollback
- revert commit `c257aa1` to remove route and docs

## Testing
- `pnpm build`
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c36d21cbf08329938fe92bb26dfcb8