### PR TITLE
feat: add async geolocation session flow

### DIFF
--- a/app/api/stamp/geo-update/route.ts
+++ b/app/api/stamp/geo-update/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { updateSessionGeo, getSession } from '@/lib/session-store';
+import { validateGeoUpdateRequest } from '../validator';
+
+export const runtime = 'nodejs';
+
+function ok(sessionId: string, status: 'geo_pending' | 'accepted' | 'rejected') {
+  return NextResponse.json({ ok: true, sessionId, status });
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return ok('unknown', 'geo_pending');
+  }
+
+  const parsed = validateGeoUpdateRequest(await req.json());
+  if (!parsed.success) {
+    return ok('unknown', 'geo_pending');
+  }
+
+  const { sessionId, lat, lon, lng, accuracy, positionTimestamp } = parsed.data;
+  const longitude = lon ?? lng!;
+
+  try {
+    const existing = getSession(sessionId);
+    if (!existing) {
+      return ok(sessionId, 'geo_pending');
+    }
+
+    await updateSessionGeo(sessionId, {
+      lat,
+      lon: longitude,
+      accuracy,
+      positionTimestamp,
+    });
+
+    const updated = getSession(sessionId);
+    return ok(sessionId, updated?.status ?? 'geo_pending');
+  } catch (error) {
+    console.error('geo-update failed', error);
+    return ok(sessionId, 'geo_pending');
+  }
+}
+

--- a/app/api/stamp/route.ts
+++ b/app/api/stamp/route.ts
@@ -1,150 +1,65 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
-import {
-  logsTable,
-  machinesTable,
-  sitesTable,
-} from '@/lib/airtable';
-import { findNearestSite } from '@/lib/geo';
-import { LogFields } from '@/types';
-import { validateStampRequest } from './validator';
+import { machinesTable } from '@/lib/airtable';
+import { createSession, updateSessionGeo } from '@/lib/session-store';
+import { validateStartRequest } from './validator';
 
 export const runtime = 'nodejs';
 
-function errorResponse(
-  code: string,
-  reason: string,
-  hint: string,
-  status: number,
-) {
-  return NextResponse.json({ ok: false, code, reason, hint }, { status });
+function ok(sessionId: string, status: 'geo_pending' | 'accepted' | 'rejected') {
+  return NextResponse.json({ ok: true, sessionId, status });
+}
+
+function badRequest(hint: string) {
+  return NextResponse.json({ ok: false, hint }, { status: 400 });
 }
 
 export async function POST(req: NextRequest) {
   const session = await auth();
   if (!session?.user?.id) {
-    return errorResponse(
-      'UNAUTHORIZED',
-      'Authentication required',
-      'Sign in and retry',
-      401,
-    );
+    return NextResponse.json({ ok: false, reason: 'UNAUTHORIZED' }, { status: 401 });
   }
 
-  const parsed = validateStampRequest(await req.json());
+  const parsed = validateStartRequest(await req.json());
   if (!parsed.success) {
-    return errorResponse('INVALID_BODY', 'Invalid request body', parsed.hint, 400);
+    return badRequest(parsed.hint);
   }
 
-  const {
-    machineId,
-    workDescription,
-    lat,
-    lon,
-    accuracy,
-    type,
-    positionTimestamp,
-    decisionThreshold,
-  } = parsed.data;
+  const { machineId, workDescription, type, lat, lon, lng, accuracy, positionTimestamp } =
+    parsed.data;
+  const longitude = lon ?? lng;
 
   try {
     const machineRecords = await machinesTable
-      .select({
-        filterByFormula: `{machineid} = '${machineId}'`,
-        maxRecords: 1,
-      })
+      .select({ filterByFormula: `{machineid} = '${machineId}'`, maxRecords: 1 })
       .firstPage();
 
     if (machineRecords.length === 0 || !machineRecords[0].fields.active) {
-      return errorResponse(
-        'INVALID_MACHINE',
-        'Invalid or inactive machine ID',
-        'Check machineId',
-        400,
-      );
+      return badRequest('Invalid or inactive machine ID');
     }
-    const machineRecordId = machineRecords[0].id;
 
-    const activeSites = await sitesTable.select({ filterByFormula: '{active} = 1' }).all();
-    const nearestSite = findNearestSite(lat, lon, activeSites);
-    const haversineDistance = (
-      lat1: number,
-      lon1: number,
-      lat2: number,
-      lon2: number,
-    ) => {
-      const R = 6371e3;
-      const toRad = (deg: number) => (deg * Math.PI) / 180;
-      const dLat = toRad(lat2 - lat1);
-      const dLon = toRad(lon2 - lon1);
-      const a =
-        Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-        Math.cos(toRad(lat1)) *
-          Math.cos(toRad(lat2)) *
-          Math.sin(dLon / 2) *
-          Math.sin(dLon / 2);
-      const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-      return R * c;
-    };
-    const distanceToSite = nearestSite
-      ? haversineDistance(lat, lon, nearestSite.fields.lat, nearestSite.fields.lon)
-      : Number.POSITIVE_INFINITY;
-    const threshold = decisionThreshold ?? 300;
-    const fresh =
-      typeof positionTimestamp === 'number'
-        ? Date.now() - positionTimestamp <= 30_000
-        : false;
-    const accurate = typeof accuracy === 'number' ? accuracy <= 100 : false;
-    const within = distanceToSite <= threshold;
-    const needsReview = !fresh || !accurate || !within;
-
-    const now = new Date();
-    const timestamp = now.toISOString();
-    const dateJST = new Intl.DateTimeFormat('ja-JP', {
-      timeZone: 'Asia/Tokyo',
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-    }).format(now).replace(/\//g, '-');
-
-    const dataToCreate: Omit<LogFields, 'user' | 'machine'> & {
-      user: readonly string[];
-      machine: readonly string[];
-    } = {
-      timestamp,
-      date: dateJST,
-      user: [session.user.id], // AirtableのUsersテーブルのレコードID
-      machine: [machineRecordId],
-      lat,
-      lon,
-      accuracy,
-      positionTimestamp,
-      distanceToSite,
-      decisionThreshold: threshold,
-      siteName: nearestSite?.fields.name ?? '特定不能',
+    const sessionEntry = createSession({
+      userId: session.user.id,
+      machineId,
+      machineRecordId: machineRecords[0].id,
       workDescription,
       type,
-      serverDecision: needsReview ? 'needs_review' : 'accepted',
-      status: needsReview ? 'needs_review' : 'accepted',
-    };
+      startedAt: Date.now(),
+    });
 
-    await logsTable.create([{ fields: dataToCreate }]);
+    if (lat !== undefined && longitude !== undefined) {
+      await updateSessionGeo(sessionEntry.sessionId, {
+        lat,
+        lon: longitude,
+        accuracy,
+        positionTimestamp,
+      });
+    }
 
-    return NextResponse.json(
-      {
-        ok: true,
-        message: 'Stamp recorded successfully',
-        serverDecision: needsReview ? 'needs_review' : 'accepted',
-      },
-      { status: 201 },
-    );
+    return ok(sessionEntry.sessionId, sessionEntry.status);
   } catch (error) {
-    console.error('Failed to record stamp:', error);
-    return errorResponse(
-      'INTERNAL_ERROR',
-      'Internal Server Error',
-      'Retry later',
-      500,
-    );
+    console.error('start failed', error);
+    return ok('unknown', 'geo_pending');
   }
 }
+

--- a/app/api/stamp/validator.ts
+++ b/app/api/stamp/validator.ts
@@ -1,40 +1,61 @@
-export type StampRequest = {
+export type StartRequest = {
   machineId: string;
   workDescription: string;
-  lat: number;
-  lon: number;
+  type: 'IN' | 'OUT';
+  lat?: number;
+  lon?: number;
+  lng?: number;
   accuracy?: number;
   positionTimestamp?: number;
-  distanceToSite?: number;
-  decisionThreshold?: number;
-  clientDecision?: 'auto' | 'blocked';
-  siteId?: string;
-  type: 'IN' | 'OUT';
 };
 
-export function validateStampRequest(
+export type GeoUpdateRequest = {
+  sessionId: string;
+  lat: number;
+  lon?: number;
+  lng?: number;
+  accuracy?: number;
+  positionTimestamp?: number;
+};
+
+function isNumber(value: unknown): value is number {
+  return typeof value === 'number' && !Number.isNaN(value);
+}
+
+export function validateStartRequest(
   data: unknown,
-): { success: true; data: StampRequest } | { success: false; hint: string } {
-  const body = data as Partial<StampRequest>;
+): { success: true; data: StartRequest } | { success: false; hint: string } {
+  const body = data as Partial<StartRequest>;
   if (
     typeof body.machineId !== 'string' ||
     typeof body.workDescription !== 'string' ||
-    typeof body.lat !== 'number' ||
-    typeof body.lon !== 'number' ||
-    (body.accuracy !== undefined && typeof body.accuracy !== 'number') ||
-    (body.positionTimestamp !== undefined && typeof body.positionTimestamp !== 'number') ||
-    (body.distanceToSite !== undefined && typeof body.distanceToSite !== 'number') ||
-    (body.decisionThreshold !== undefined && typeof body.decisionThreshold !== 'number') ||
-    (body.clientDecision !== undefined &&
-      body.clientDecision !== 'auto' &&
-      body.clientDecision !== 'blocked') ||
-    (body.siteId !== undefined && typeof body.siteId !== 'string') ||
-    (body.type !== 'IN' && body.type !== 'OUT')
+    (body.type !== 'IN' && body.type !== 'OUT') ||
+    (body.lat !== undefined && !isNumber(body.lat)) ||
+    (body.lon !== undefined && !isNumber(body.lon)) ||
+    (body.lng !== undefined && !isNumber(body.lng)) ||
+    (body.accuracy !== undefined && !isNumber(body.accuracy)) ||
+    (body.positionTimestamp !== undefined && !isNumber(body.positionTimestamp))
   ) {
-    return {
-      success: false,
-      hint: 'machineId, workDescription, lat, lon, type are required',
-    };
+    return { success: false, hint: 'machineId, workDescription, type are required' };
   }
-  return { success: true, data: body as StampRequest };
+  return { success: true, data: body as StartRequest };
 }
+
+export function validateGeoUpdateRequest(
+  data: unknown,
+): { success: true; data: GeoUpdateRequest } | { success: false; hint: string } {
+  const body = data as Partial<GeoUpdateRequest>;
+  if (
+    typeof body.sessionId !== 'string' ||
+    !isNumber(body.lat) ||
+    (body.lon === undefined && body.lng === undefined) ||
+    (body.lon !== undefined && !isNumber(body.lon)) ||
+    (body.lng !== undefined && !isNumber(body.lng)) ||
+    (body.accuracy !== undefined && !isNumber(body.accuracy)) ||
+    (body.positionTimestamp !== undefined && !isNumber(body.positionTimestamp))
+  ) {
+    return { success: false, hint: 'sessionId, lat, lon|lng are required' };
+  }
+  return { success: true, data: body as GeoUpdateRequest };
+}
+

--- a/lib/session-store.ts
+++ b/lib/session-store.ts
@@ -1,0 +1,151 @@
+import crypto from 'node:crypto';
+import { logsTable, sitesTable } from '@/lib/airtable';
+import { findNearestSite } from '@/lib/geo';
+import type { LogFields } from '@/types';
+
+export type GeoSession = {
+  sessionId: string;
+  status: 'geo_pending' | 'accepted' | 'rejected';
+  userId: string;
+  machineId: string;
+  machineRecordId: string;
+  workDescription: string;
+  type: 'IN' | 'OUT';
+  startedAt: number;
+  lat?: number;
+  lon?: number;
+  accuracy?: number;
+  positionTimestamp?: number;
+  decisionThreshold?: number;
+  distanceToSite?: number;
+  syncedAt?: string;
+  airtableRecordId?: string;
+};
+
+const sessions = new Map<string, GeoSession>();
+
+export function createSession(
+  params: Omit<
+    GeoSession,
+    | 'sessionId'
+    | 'status'
+    | 'lat'
+    | 'lon'
+    | 'accuracy'
+    | 'positionTimestamp'
+    | 'decisionThreshold'
+    | 'distanceToSite'
+    | 'syncedAt'
+    | 'airtableRecordId'
+  >,
+): GeoSession {
+  const sessionId = crypto.randomUUID();
+  const session: GeoSession = {
+    ...params,
+    sessionId,
+    status: 'geo_pending',
+  };
+  sessions.set(sessionId, session);
+  return session;
+}
+
+function haversineDistance(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number,
+): number {
+  const R = 6371e3;
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRad(lat1)) *
+      Math.cos(toRad(lat2)) *
+      Math.sin(dLon / 2) *
+      Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
+export async function updateSessionGeo(
+  sessionId: string,
+  geo: { lat: number; lon: number; accuracy?: number; positionTimestamp?: number },
+): Promise<GeoSession | null> {
+  const session = sessions.get(sessionId);
+  if (!session) return null;
+
+  session.lat = geo.lat;
+  session.lon = geo.lon;
+  session.accuracy = geo.accuracy;
+  session.positionTimestamp = geo.positionTimestamp;
+
+  try {
+    const activeSites = await sitesTable.select({ filterByFormula: '{active} = 1' }).all();
+    const nearestSite = findNearestSite(geo.lat, geo.lon, activeSites);
+    const distanceToSite = nearestSite
+      ? haversineDistance(geo.lat, geo.lon, nearestSite.fields.lat, nearestSite.fields.lon)
+      : Number.POSITIVE_INFINITY;
+    const threshold = Math.max(150, (geo.accuracy ?? 150) * 2);
+    const fresh =
+      typeof geo.positionTimestamp === 'number'
+        ? Date.now() - geo.positionTimestamp <= 30_000
+        : false;
+    const accurate = typeof geo.accuracy === 'number' ? geo.accuracy <= 100 : false;
+    const within = distanceToSite <= threshold;
+    const accepted = within && fresh && accurate;
+
+    session.distanceToSite = distanceToSite;
+    session.decisionThreshold = threshold;
+
+    if (accepted && session.status !== 'accepted') {
+      const now = new Date();
+      const timestamp = now.toISOString();
+      const dateJST = new Intl.DateTimeFormat('ja-JP', {
+        timeZone: 'Asia/Tokyo',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+      })
+        .format(now)
+        .replace(/\//g, '-');
+
+      const fields: Omit<LogFields, 'user' | 'machine'> & {
+        user: readonly string[];
+        machine: readonly string[];
+      } = {
+        timestamp,
+        date: dateJST,
+        user: [session.userId],
+        machine: [session.machineRecordId],
+        lat: geo.lat,
+        lon: geo.lon,
+        accuracy: geo.accuracy,
+        positionTimestamp: geo.positionTimestamp,
+        distanceToSite,
+        decisionThreshold: threshold,
+        siteName: nearestSite?.fields.name ?? '特定不能',
+        workDescription: session.workDescription,
+        type: session.type,
+        serverDecision: 'accepted',
+        status: 'accepted',
+        sessionId: session.sessionId,
+      };
+
+      const created = await logsTable.create([{ fields }]);
+      session.status = 'accepted';
+      session.syncedAt = timestamp;
+      session.airtableRecordId = created[0].id;
+    }
+  } catch (error) {
+    console.error('geo update failed', error);
+  }
+
+  return session;
+}
+
+export function getSession(sessionId: string): GeoSession | undefined {
+  return sessions.get(sessionId);
+}
+

--- a/tests/stamp.test.mjs
+++ b/tests/stamp.test.mjs
@@ -1,55 +1,31 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { validateStampRequest } from './dist/validator.js';
+import {
+  validateStartRequest,
+  validateGeoUpdateRequest,
+} from './dist/validator.js';
 
-test('validateStampRequest fails on missing fields', () => {
-  const result = validateStampRequest({});
+test('validateStartRequest fails on missing fields', () => {
+  const result = validateStartRequest({});
   assert.strictEqual(result.success, false);
 });
 
-test('validateStampRequest succeeds on valid data', () => {
-  const result = validateStampRequest({
+test('validateStartRequest succeeds on minimal data', () => {
+  const result = validateStartRequest({
     machineId: '1',
     workDescription: 'test',
-    lat: 0,
-    lon: 0,
     type: 'IN',
   });
   assert.strictEqual(result.success, true);
 });
 
-test('validateStampRequest fails on invalid type', () => {
-  const result = validateStampRequest({
-    machineId: '1',
-    workDescription: 'test',
-    lat: 0,
-    lon: 0,
-    type: 'INVALID',
-  });
+test('validateGeoUpdateRequest requires lon or lng', () => {
+  const result = validateGeoUpdateRequest({ sessionId: 's', lat: 0 });
   assert.strictEqual(result.success, false);
 });
 
-test('validateStampRequest fails on invalid accuracy type', () => {
-  const result = validateStampRequest({
-    machineId: '1',
-    workDescription: 'test',
-    lat: 0,
-    lon: 0,
-    type: 'IN',
-    accuracy: 'bad',
-  });
-  assert.strictEqual(result.success, false);
-});
-
-test('validateStampRequest fails on invalid clientDecision', () => {
-  const result = validateStampRequest({
-    machineId: '1',
-    workDescription: 'test',
-    lat: 0,
-    lon: 0,
-    type: 'IN',
-    clientDecision: 'wrong',
-  });
-  assert.strictEqual(result.success, false);
+test('validateGeoUpdateRequest accepts lng', () => {
+  const result = validateGeoUpdateRequest({ sessionId: 's', lat: 0, lng: 0 });
+  assert.strictEqual(result.success, true);
 });
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -42,11 +42,14 @@ export interface LogFields extends FieldSet {
   positionTimestamp?: number;
   distanceToSite?: number;
   decisionThreshold?: number;
+  sessionId?: string;
   serverDecision?: 'accepted' | 'needs_review';
   status?: 'accepted' | 'needs_review' | 'rejected';
   siteName?: string;
   workDescription?: string;
   type: 'IN' | 'OUT';
+  syncedAt?: string;
+  airtableRecordId?: string;
 }
 
 export type StampPayload = {


### PR DESCRIPTION
## Purpose
- remove override UI and make stamping non-blocking
- handle geolocation asynchronously with session evaluation

## Changes
- add in-memory session store and geo-update API
- rewrite stamp API to always respond 200 and evaluate location later
- simplify StampCard client to send start immediately and geo updates in background
- extend log type and validators for optional session fields

## Impact
- stamping requests now return sessionId with status `geo_pending` until location accepted
- Airtable writes occur only after geo criteria met

## Rollback
- revert commit `feat: add async geolocation session flow`

## Testing
- `pnpm build`
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c419863c808329ae554d323bf3543a