### PR TITLE
feat: prioritize polygon containment

### DIFF
--- a/app/api/stamp/route.ts
+++ b/app/api/stamp/route.ts
@@ -5,7 +5,7 @@ import {
   machinesTable,
   sitesTable,
 } from '@/lib/airtable';
-import { findNearestSite } from '@/lib/geo';
+import { findNearestSiteDetailed } from '@/lib/geo';
 import { LogFields } from '@/types';
 import { validateStampRequest } from './validator';
 
@@ -65,35 +65,14 @@ export async function POST(req: NextRequest) {
     const machineRecordId = machineRecords[0].id;
 
     const activeSites = await sitesTable.select({ filterByFormula: '{active} = 1' }).all();
-    const { site: nearestSite, method: decisionMethod } = findNearestSite(lat, lon, activeSites);
-    const haversineDistance = (
-      lat1: number,
-      lon1: number,
-      lat2: number,
-      lon2: number,
-    ) => {
-      const R = 6371e3;
-      const toRad = (deg: number) => (deg * Math.PI) / 180;
-      const dLat = toRad(lat2 - lat1);
-      const dLon = toRad(lon2 - lon1);
-      const a =
-        Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-        Math.cos(toRad(lat1)) *
-          Math.cos(toRad(lat2)) *
-          Math.sin(dLon / 2) *
-          Math.sin(dLon / 2);
-      const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-      return R * c;
-    };
-    const distanceToSite = nearestSite
-      ? haversineDistance(lat, lon, nearestSite.fields.lat, nearestSite.fields.lon)
-      : Number.POSITIVE_INFINITY;
+    const { site: nearestSite, method: decisionMethod, nearestDistanceM } =
+      findNearestSiteDetailed(lat, lon, activeSites);
     const fresh =
       typeof positionTimestamp === 'number'
         ? Date.now() - positionTimestamp <= 30_000
         : false;
     const lowAccuracy = typeof accuracy === 'number' ? accuracy > 100 : false;
-    const tooFar = distanceToSite > 1000;
+    const tooFar = typeof nearestDistanceM === 'number' ? nearestDistanceM > 1000 : false;
     const needsReview = !fresh || lowAccuracy || tooFar;
 
     const now = new Date();
@@ -118,7 +97,7 @@ export async function POST(req: NextRequest) {
       accuracy,
       low_accuracy: lowAccuracy,
       positionTimestamp,
-      distanceToSite,
+      distanceToSite: nearestDistanceM ?? undefined,
       decision_method: decisionMethod,
       too_far: tooFar,
       siteName: nearestSite?.fields.name ?? '特定不能',
@@ -135,7 +114,7 @@ export async function POST(req: NextRequest) {
         ok: true,
         decidedSiteId: nearestSite?.fields.siteId ?? null,
         decision_method: decisionMethod,
-        nearest_distance_m: distanceToSite,
+        nearest_distance_m: nearestDistanceM ?? null,
         accuracy,
         low_accuracy: lowAccuracy,
         too_far: tooFar,

--- a/app/api/stamp/validator.ts
+++ b/app/api/stamp/validator.ts
@@ -5,8 +5,6 @@ export type StampRequest = {
   lon: number;
   accuracy?: number;
   positionTimestamp?: number;
-  distanceToSite?: number;
-  decisionThreshold?: number;
   clientDecision?: 'auto' | 'blocked';
   siteId?: string;
   type: 'IN' | 'OUT';
@@ -23,8 +21,6 @@ export function validateStampRequest(
     typeof body.lon !== 'number' ||
     (body.accuracy !== undefined && typeof body.accuracy !== 'number') ||
     (body.positionTimestamp !== undefined && typeof body.positionTimestamp !== 'number') ||
-    (body.distanceToSite !== undefined && typeof body.distanceToSite !== 'number') ||
-    (body.decisionThreshold !== undefined && typeof body.decisionThreshold !== 'number') ||
     (body.clientDecision !== undefined &&
       body.clientDecision !== 'auto' &&
       body.clientDecision !== 'blocked') ||

--- a/components/StampCard.tsx
+++ b/components/StampCard.tsx
@@ -36,6 +36,7 @@ export default function StampCard({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
   const [warning, setWarning] = useState('');
+  const [decisionMethod, setDecisionMethod] = useState('');
   const [lastWorkDescription, setLastWorkDescription] = useState(initialWorkDescription);
   const [selectedWork, setSelectedWork] = useState('');
 
@@ -104,13 +105,17 @@ export default function StampCard({
           });
           const data = await response.json();
           const warnings: string[] = [];
-          if (data.low_accuracy) {
+          if (typeof data.accuracy === 'number' && data.accuracy > 100) {
             warnings.push('位置精度が低い可能性があります（>100m）');
           }
-          if (data.too_far) {
+          if (
+            typeof data.nearest_distance_m === 'number' &&
+            data.nearest_distance_m > 1000
+          ) {
             warnings.push('登録拠点から離れている可能性があります（>1km）');
           }
           setWarning(warnings.join(' / '));
+          setDecisionMethod(data.decision_method ?? '');
           if (!response.ok) {
             throw new Error(data.message || `サーバーエラー: ${response.statusText}`);
           }
@@ -162,12 +167,15 @@ export default function StampCard({
 
   return (
     <div className="flex min-h-[calc(100svh-56px)] w-full flex-col items-center gap-6 p-4 pb-[calc(env(safe-area-inset-bottom)+12px)]">
-      {warning && (
+      {(warning || decisionMethod) && (
         <div
           role="alert"
           className="w-[90vw] max-w-[560px] rounded bg-yellow-50 p-2 text-sm text-yellow-800"
         >
           {warning}
+          {decisionMethod && (
+            <span className="ml-2 text-xs">method: {decisionMethod}</span>
+          )}
         </div>
       )}
       <div className="card w-[90vw] max-w-[560px] mx-auto">

--- a/lib/airtableSchema.ts
+++ b/lib/airtableSchema.ts
@@ -1,0 +1,27 @@
+export const LOGS_ALLOWED_FIELDS = [
+  'timestamp',
+  'date',
+  'user',
+  'machine',
+  'siteName',
+  'lat',
+  'lon',
+  'accuracy',
+  'work',
+  'workDescription',
+  'type',
+] as const;
+
+export type LogsAllowedKey = (typeof LOGS_ALLOWED_FIELDS)[number];
+
+export function filterFields<T extends Record<string, unknown>>(
+  candidate: T,
+  allowed: readonly string[],
+  { dropNull = true } = {},
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(candidate).filter(
+      ([k, v]) => allowed.includes(k) && (!dropNull || v != null),
+    ),
+  );
+}

--- a/lib/geo.ts
+++ b/lib/geo.ts
@@ -1,8 +1,21 @@
 import { SiteFields } from '@/types';
 import { Record } from 'airtable';
 
+type Polygon = {
+  type: 'Polygon';
+  coordinates: number[][][];
+};
+
+type MultiPolygon = {
+  type: 'MultiPolygon';
+  coordinates: number[][][][];
+};
+
+export type Geometry = Polygon | MultiPolygon;
+export type DecisionMethod = 'gps_polygon' | 'gps_nearest';
+
 // 2点間の距離を計算するハバーサイン公式
-const haversineDistance = (
+export const haversineDistance = (
   lat1: number,
   lon1: number,
   lat2: number,
@@ -22,14 +35,84 @@ const haversineDistance = (
   return R * c; // 距離 (メートル)
 };
 
+type Feature = { type: 'Feature'; geometry?: Geometry };
+type FeatureCollection = { type: 'FeatureCollection'; features?: Feature[] };
+type Raw = Geometry | Feature | FeatureCollection;
+
+export const extractGeometry = (raw: string | null): Geometry | null => {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Raw;
+    const geom =
+      parsed.type === 'FeatureCollection'
+        ? parsed.features?.[0]?.geometry
+        : parsed.type === 'Feature'
+          ? parsed.geometry
+          : parsed;
+    if (geom && (geom.type === 'Polygon' || geom.type === 'MultiPolygon')) {
+      return geom;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+const pointInRing = (
+  lat: number,
+  lon: number,
+  ring: readonly number[][]
+): boolean => {
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const [lonI, latI] = ring[i];
+    const [lonJ, latJ] = ring[j];
+    const intersect =
+      latI > lat !== latJ > lat &&
+      lon < ((lonJ - lonI) * (lat - latI)) / (latJ - latI) + lonI;
+    if (intersect) inside = !inside;
+  }
+  return inside;
+};
+
+const pointInPolygon = (
+  lat: number,
+  lon: number,
+  coords: readonly number[][][]
+): boolean => {
+  if (!pointInRing(lat, lon, coords[0])) return false;
+  for (let i = 1; i < coords.length; i++) {
+    if (pointInRing(lat, lon, coords[i])) return false;
+  }
+  return true;
+};
+
+export const pointInGeometry = (
+  lat: number,
+  lon: number,
+  geometry: Geometry
+): boolean => {
+  if (geometry.type === 'Polygon') {
+    return pointInPolygon(lat, lon, geometry.coordinates);
+  }
+  return geometry.coordinates.some((p) => pointInPolygon(lat, lon, p));
+};
+
 // 現場リストの中から最も近い現場を見つける関数
 export const findNearestSite = (
   lat: number,
   lon: number,
   sites: readonly Record<SiteFields>[]
-): Record<SiteFields> | null => {
+): { site: Record<SiteFields> | null; method: DecisionMethod } => {
   if (sites.length === 0) {
-    return null;
+    return { site: null, method: 'gps_nearest' };
+  }
+
+  for (const site of sites) {
+    const geom = extractGeometry(site.fields.polygon_geojson ?? null);
+    if (geom && pointInGeometry(lat, lon, geom)) {
+      return { site, method: 'gps_polygon' };
+    }
   }
 
   let nearestSite: Record<SiteFields> | null = null;
@@ -43,5 +126,5 @@ export const findNearestSite = (
     }
   }
 
-  return nearestSite;
+  return { site: nearestSite, method: 'gps_nearest' };
 };

--- a/lib/geo.ts
+++ b/lib/geo.ts
@@ -45,9 +45,10 @@ type FeatureCollection = { type: 'FeatureCollection'; features?: Feature[] };
 type Raw = Geometry | Feature | FeatureCollection;
 
 export const extractGeometry = (raw: string | null): Geometry | null => {
-  if (!raw) return null;
+  const trimmed = raw?.trim();
+  if (!trimmed) return null;
   try {
-    const parsed = JSON.parse(raw) as Raw;
+    const parsed = JSON.parse(trimmed) as Raw;
     const geom =
       parsed.type === 'FeatureCollection'
         ? parsed.features?.[0]?.geometry
@@ -58,7 +59,8 @@ export const extractGeometry = (raw: string | null): Geometry | null => {
       return geom;
     }
     return null;
-  } catch {
+  } catch (e) {
+    console.warn('[geo] polygon parse failed', { raw: trimmed, error: e });
     return null;
   }
 };

--- a/tests/airtableSchema.test.mjs
+++ b/tests/airtableSchema.test.mjs
@@ -1,0 +1,25 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+execSync(
+  'pnpm exec tsc -p tsconfig.json --outDir tests/dist --module nodenext --target es2020 --moduleResolution nodenext --esModuleInterop --noEmit false',
+  { cwd: root, stdio: 'inherit' },
+);
+
+const { filterFields, LOGS_ALLOWED_FIELDS } = await import('./dist/lib/airtableSchema.js');
+
+test('filterFields removes unknown keys and nulls', () => {
+  const candidate = {
+    timestamp: '2024-01-01T00:00:00Z',
+    lat: 1,
+    unknown: 'x',
+    nullField: null,
+  };
+  const result = filterFields(candidate, LOGS_ALLOWED_FIELDS);
+  assert.deepStrictEqual(result, { timestamp: '2024-01-01T00:00:00Z', lat: 1 });
+});

--- a/tests/geo.test.mjs
+++ b/tests/geo.test.mjs
@@ -1,0 +1,56 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+execSync(
+  'pnpm exec tsc -p tsconfig.json --outDir tests/dist --module nodenext --target es2020 --moduleResolution nodenext --esModuleInterop --noEmit false',
+  { cwd: root, stdio: 'inherit' }
+);
+
+const { findNearestSite } = await import('./dist/lib/geo.js');
+
+test('findNearestSite prioritizes polygon containment', () => {
+  const polygon = {
+    type: 'Polygon',
+    coordinates: [[[-1, -1], [1, -1], [1, 1], [-1, 1], [-1, -1]]],
+  };
+  const siteWithPolygon = {
+    fields: {
+      siteId: '1',
+      name: 'poly',
+      lat: 100,
+      lon: 100,
+      client: 'c',
+      polygon_geojson: JSON.stringify(polygon),
+    },
+  };
+  const nearbySite = {
+    fields: { siteId: '2', name: 'near', lat: 0.1, lon: 0.1, client: 'c' },
+  };
+  const result = findNearestSite(0, 0, [nearbySite, siteWithPolygon]);
+  assert.strictEqual(result.site, siteWithPolygon);
+  assert.strictEqual(result.method, 'gps_polygon');
+});
+
+test('findNearestSite falls back to nearest distance', () => {
+  const siteA = {
+    fields: { siteId: '1', name: 'A', lat: 0, lon: 0, client: 'c' },
+  };
+  const siteB = {
+    fields: {
+      siteId: '2',
+      name: 'B',
+      lat: 0,
+      lon: 1,
+      client: 'c',
+      polygon_geojson: 'invalid',
+    },
+  };
+  const result = findNearestSite(0, 0, [siteA, siteB]);
+  assert.strictEqual(result.site, siteA);
+  assert.strictEqual(result.method, 'gps_nearest');
+});

--- a/tests/geo.test.mjs
+++ b/tests/geo.test.mjs
@@ -11,7 +11,7 @@ execSync(
   { cwd: root, stdio: 'inherit' }
 );
 
-const { findNearestSite } = await import('./dist/lib/geo.js');
+const { findNearestSite, pointInGeometry } = await import('./dist/lib/geo.js');
 
 test('findNearestSite prioritizes polygon containment', () => {
   const polygon = {
@@ -53,4 +53,27 @@ test('findNearestSite falls back to nearest distance', () => {
   const result = findNearestSite(0, 0, [siteA, siteB]);
   assert.strictEqual(result.site, siteA);
   assert.strictEqual(result.method, 'gps_nearest');
+});
+
+test('pointInGeometry excludes holes', () => {
+  const polygon = {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [0, 0],
+        [2, 0],
+        [2, 2],
+        [0, 2],
+        [0, 0],
+      ],
+      [
+        [0.5, 0.5],
+        [0.5, 1.5],
+        [1.5, 1.5],
+        [1.5, 0.5],
+        [0.5, 0.5],
+      ],
+    ],
+  };
+  assert.strictEqual(pointInGeometry(1, 1, polygon), false);
 });

--- a/tests/geo.test.mjs
+++ b/tests/geo.test.mjs
@@ -11,7 +11,7 @@ execSync(
   { cwd: root, stdio: 'inherit' }
 );
 
-const { findNearestSite, pointInGeometry } = await import('./dist/lib/geo.js');
+const { findNearestSiteDetailed, pointInGeometry } = await import('./dist/lib/geo.js');
 
 test('findNearestSite prioritizes polygon containment', () => {
   const polygon = {
@@ -31,9 +31,10 @@ test('findNearestSite prioritizes polygon containment', () => {
   const nearbySite = {
     fields: { siteId: '2', name: 'near', lat: 0.1, lon: 0.1, client: 'c' },
   };
-  const result = findNearestSite(0, 0, [nearbySite, siteWithPolygon]);
+  const result = findNearestSiteDetailed(0, 0, [nearbySite, siteWithPolygon]);
   assert.strictEqual(result.site, siteWithPolygon);
   assert.strictEqual(result.method, 'gps_polygon');
+  assert.strictEqual(result.nearestDistanceM, 0);
 });
 
 test('findNearestSite falls back to nearest distance', () => {
@@ -50,9 +51,10 @@ test('findNearestSite falls back to nearest distance', () => {
       polygon_geojson: 'invalid',
     },
   };
-  const result = findNearestSite(0, 0, [siteA, siteB]);
+  const result = findNearestSiteDetailed(0, 0, [siteA, siteB]);
   assert.strictEqual(result.site, siteA);
   assert.strictEqual(result.method, 'gps_nearest');
+  assert(result.nearestDistanceM < 100);
 });
 
 test('pointInGeometry excludes holes', () => {

--- a/types/index.ts
+++ b/types/index.ts
@@ -41,14 +41,8 @@ export interface LogFields extends FieldSet {
   lat?: number;
   lon?: number;
   accuracy?: number;
-  low_accuracy?: boolean;
-  positionTimestamp?: number;
-  distanceToSite?: number;
-  decision_method?: 'gps_polygon' | 'gps_nearest';
-  too_far?: boolean;
-  serverDecision?: 'accepted' | 'needs_review';
-  status?: 'accepted' | 'needs_review' | 'rejected';
   siteName?: string;
+  work?: number;
   workDescription?: string;
   type: 'IN' | 'OUT';
 }
@@ -68,12 +62,5 @@ export type StampRecord = {
   lat: number;
   lon: number;
   accuracy?: number;
-  low_accuracy?: boolean;
-  positionTimestamp?: number;
-  distanceToSite?: number;
-  decision_method?: 'gps_polygon' | 'gps_nearest';
-  too_far?: boolean;
-  serverDecision?: 'accepted' | 'needs_review';
-  status?: 'accepted' | 'needs_review' | 'rejected';
   createdAt: string;
 };

--- a/types/index.ts
+++ b/types/index.ts
@@ -20,6 +20,8 @@ export interface SiteFields extends FieldSet {
   name: string;
   lat: number;
   lon: number;
+  // @ts-expect-error Airtable FieldSet does not include null
+  polygon_geojson?: string | null;
   client: string;
   active?: boolean;
 }
@@ -39,9 +41,11 @@ export interface LogFields extends FieldSet {
   lat?: number;
   lon?: number;
   accuracy?: number;
+  low_accuracy?: boolean;
   positionTimestamp?: number;
   distanceToSite?: number;
   decisionThreshold?: number;
+  decision_method?: 'gps_polygon' | 'gps_nearest';
   serverDecision?: 'accepted' | 'needs_review';
   status?: 'accepted' | 'needs_review' | 'rejected';
   siteName?: string;
@@ -66,9 +70,11 @@ export type StampRecord = {
   lat: number;
   lon: number;
   accuracy?: number;
+  low_accuracy?: boolean;
   positionTimestamp?: number;
   distanceToSite?: number;
   decisionThreshold?: number;
+  decision_method?: 'gps_polygon' | 'gps_nearest';
   serverDecision?: 'accepted' | 'needs_review';
   status?: 'accepted' | 'needs_review' | 'rejected';
   createdAt: string;

--- a/types/index.ts
+++ b/types/index.ts
@@ -44,8 +44,8 @@ export interface LogFields extends FieldSet {
   low_accuracy?: boolean;
   positionTimestamp?: number;
   distanceToSite?: number;
-  decisionThreshold?: number;
   decision_method?: 'gps_polygon' | 'gps_nearest';
+  too_far?: boolean;
   serverDecision?: 'accepted' | 'needs_review';
   status?: 'accepted' | 'needs_review' | 'rejected';
   siteName?: string;
@@ -59,8 +59,6 @@ export type StampPayload = {
   lon: number;
   accuracy?: number;
   positionTimestamp?: number;
-  distanceToSite?: number;
-  decisionThreshold?: number;
   clientDecision?: 'auto' | 'blocked';
 };
 
@@ -73,8 +71,8 @@ export type StampRecord = {
   low_accuracy?: boolean;
   positionTimestamp?: number;
   distanceToSite?: number;
-  decisionThreshold?: number;
   decision_method?: 'gps_polygon' | 'gps_nearest';
+  too_far?: boolean;
   serverDecision?: 'accepted' | 'needs_review';
   status?: 'accepted' | 'needs_review' | 'rejected';
   createdAt: string;


### PR DESCRIPTION
## Summary
- extend SiteFields with optional `polygon_geojson`
- add geometry helpers and polygon-first logic in `findNearestSite`
- cover polygon containment and fallback cases with tests (new `tests/geo.test.mjs`)
- continue stamping even when GPS accuracy is low and record decision method

## Testing
- `pnpm build`
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4e1afee108329b0fa50d68f06de6e