### PR TITLE
fix: improve geolocation handling

### DIFF
--- a/tests/geo.test.mjs
+++ b/tests/geo.test.mjs
@@ -11,7 +11,7 @@ execSync(
   { cwd: root, stdio: 'inherit' }
 );
 
-const { findNearestSiteDetailed, pointInGeometry } = await import('./dist/lib/geo.js');
+const { extractGeometry, findNearestSiteDetailed, pointInGeometry } = await import('./dist/lib/geo.js');
 
 test('findNearestSite prioritizes polygon containment', () => {
   const polygon = {
@@ -78,4 +78,30 @@ test('pointInGeometry excludes holes', () => {
     ],
   };
   assert.strictEqual(pointInGeometry(1, 1, polygon), false);
+});
+
+test('extractGeometry resolves FeatureCollection polygons', () => {
+  const raw = JSON.stringify({
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [0, 0],
+              [1, 0],
+              [1, 1],
+              [0, 1],
+              [0, 0],
+            ],
+          ],
+        },
+      },
+    ],
+  });
+  const geometry = extractGeometry(raw);
+  assert(geometry);
+  assert.strictEqual(geometry.type, 'Polygon');
 });


### PR DESCRIPTION
目的／影響範囲／触るファイル
- 目的: 打刻処理の測位品質を向上させつつUXを維持する
- 影響範囲: /nfc の打刻フロー、警告バナー表示
- 触るファイル: components/StampCard.tsx, tests/geo.test.mjs

## 目的
- 古い測位で打刻が中断される問題を解消し、必要時のみ追加測位で精度向上を図る

## 変更点
- 測位取得を自動調整ヘルパーに差し替え、ポリゴン内・精度良好時は即時確定し、それ以外は短時間の watchPosition で補正
- 測位の古さによる中断を廃止し、警告バナーに集約して注意喚起のみ行う
- サイトポリゴン判定をフロント側で再利用し、測位改善の早期終了条件に利用
- geo ユニットテストを拡充し、FeatureCollection 入力の extractGeometry を検証

## 影響範囲
- 打刻時の測位待機時間・警告表示、/api/stamp への送信パラメータ

## ロールバック手順
- `git revert 782a032` を実行して前コミットを取り消す

## テスト結果
- pnpm build
- pnpm test
- pnpm lint


------
https://chatgpt.com/codex/tasks/task_e_68cea09e9dfc8329929de44ceef0d28d