### PR TITLE
feat(dashboard): add internal Projects & Activity Calendar

### DIFF
--- a/app/(protected)/dashboard/_components/CalendarMonth.tsx
+++ b/app/(protected)/dashboard/_components/CalendarMonth.tsx
@@ -1,0 +1,223 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState, type ReactElement } from 'react';
+import DayDrawer from './DayDrawer';
+
+type DaySummary = {
+  date: string;
+  hours: number;
+  sessions: number;
+};
+
+type CalendarResponse = {
+  year: number;
+  month: number;
+  days: DaySummary[];
+};
+
+type CalendarMonthProps = {
+  initialYear: number;
+  initialMonth: number;
+};
+
+const WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土'] as const;
+
+function formatMonth(year: number, month: number): string {
+  return `${year}年${String(month).padStart(2, '0')}月`;
+}
+
+function toDateString(year: number, month: number, day: number): string {
+  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+}
+
+function summarizeTotals(days: DaySummary[]): { hours: number; sessions: number } {
+  return days.reduce(
+    (acc, day) => {
+      return {
+        hours: acc.hours + day.hours,
+        sessions: acc.sessions + day.sessions,
+      };
+    },
+    { hours: 0, sessions: 0 },
+  );
+}
+
+function LoadingSkeleton(): ReactElement {
+  return <div className="h-64 animate-pulse rounded-2xl bg-gray-100" />;
+}
+
+function ErrorBanner({ message, onRetry }: { message: string; onRetry: () => void }): ReactElement {
+  return (
+    <div className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+      <div className="flex items-start justify-between gap-3">
+        <p className="font-medium">{message}</p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="rounded-full bg-red-600 px-3 py-1 text-xs font-semibold text-white shadow hover:bg-red-700"
+        >
+          再試行
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function CalendarMonth({ initialYear, initialMonth }: CalendarMonthProps): ReactElement {
+  const [currentYear, setCurrentYear] = useState(initialYear);
+  const [currentMonth, setCurrentMonth] = useState(initialMonth);
+  const [calendar, setCalendar] = useState<CalendarResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [drawerDate, setDrawerDate] = useState<string | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const loadCalendar = useCallback(
+    async (year: number, month: number) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch(`/api/dashboard/calendar?year=${year}&month=${month}`, { cache: 'no-store' });
+        if (!response.ok) {
+          throw new Error(`failed with status ${response.status}`);
+        }
+        const json = (await response.json()) as CalendarResponse;
+        setCalendar(json);
+      } catch (err) {
+        console.error('Failed to fetch calendar', err);
+        setError('カレンダーデータの取得に失敗しました。');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    void loadCalendar(currentYear, currentMonth);
+  }, [currentMonth, currentYear, loadCalendar]);
+
+  const summaries = useMemo(() => new Map(calendar?.days.map((day) => [day.date, day]) ?? []), [calendar]);
+
+  const totals = useMemo(() => summarizeTotals(calendar?.days ?? []), [calendar]);
+
+  const firstDay = useMemo(() => new Date(currentYear, currentMonth - 1, 1).getDay(), [currentMonth, currentYear]);
+  const daysInMonth = useMemo(() => new Date(currentYear, currentMonth, 0).getDate(), [currentMonth, currentYear]);
+
+  const grid = useMemo(() => {
+    const items: Array<string | null> = [];
+    for (let i = 0; i < firstDay; i += 1) {
+      items.push(null);
+    }
+    for (let day = 1; day <= daysInMonth; day += 1) {
+      items.push(toDateString(currentYear, currentMonth, day));
+    }
+    while (items.length % 7 !== 0) {
+      items.push(null);
+    }
+    return items;
+  }, [currentMonth, currentYear, daysInMonth, firstDay]);
+
+  const handlePrev = useCallback(() => {
+    setCurrentMonth((prev) => {
+      if (prev === 1) {
+        setCurrentYear((year) => year - 1);
+        return 12;
+      }
+      return prev - 1;
+    });
+  }, []);
+
+  const handleNext = useCallback(() => {
+    setCurrentMonth((prev) => {
+      if (prev === 12) {
+        setCurrentYear((year) => year + 1);
+        return 1;
+      }
+      return prev + 1;
+    });
+  }, []);
+
+  const openDrawer = useCallback((date: string) => {
+    setDrawerDate(date);
+    setDrawerOpen(true);
+  }, []);
+
+  const closeDrawer = useCallback(() => {
+    setDrawerOpen(false);
+    setDrawerDate(null);
+  }, []);
+
+  return (
+    <section className="rounded-2xl bg-white p-6 shadow-md">
+      <header className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900">稼働状況</h3>
+          <p className="text-sm text-gray-500">セッション数と稼働時間を月次で確認できます。</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handlePrev}
+            className="rounded-full bg-gray-200 px-3 py-1 text-xs font-semibold text-gray-700 hover:bg-gray-300"
+            aria-label="前の月へ"
+          >
+            前へ
+          </button>
+          <span className="text-sm font-medium text-gray-700" aria-live="polite">
+            {formatMonth(currentYear, currentMonth)}
+          </span>
+          <button
+            type="button"
+            onClick={handleNext}
+            className="rounded-full bg-gray-200 px-3 py-1 text-xs font-semibold text-gray-700 hover:bg-gray-300"
+            aria-label="次の月へ"
+          >
+            次へ
+          </button>
+        </div>
+      </header>
+
+      <div className="mb-4 flex flex-wrap gap-6 text-sm text-gray-600">
+        <span>総稼働時間: {totals.hours.toFixed(2)} h</span>
+        <span>総セッション数: {totals.sessions} 件</span>
+      </div>
+
+      {loading && <LoadingSkeleton />}
+      {!loading && error && <ErrorBanner message={error} onRetry={() => void loadCalendar(currentYear, currentMonth)} />}
+
+      {!loading && !error && (
+        <div className="grid grid-cols-7 gap-2" role="grid" aria-label="月次カレンダー">
+          {WEEKDAYS.map((label) => (
+            <div key={label} className="text-center text-xs font-semibold uppercase tracking-wide text-gray-400">
+              {label}
+            </div>
+          ))}
+          {grid.map((date, index) => {
+            if (!date) {
+              return <div key={`blank-${index}`} className="h-24 rounded-2xl bg-transparent" aria-hidden />;
+            }
+            const summary = summaries.get(date);
+            const dayNumber = Number(date.split('-')[2]);
+            return (
+              <button
+                key={date}
+                type="button"
+                onClick={() => openDrawer(date)}
+                className="flex h-24 flex-col justify-between rounded-2xl border border-gray-100 p-3 text-left transition hover:border-primary hover:shadow"
+              >
+                <span className="text-sm font-semibold text-gray-800">{dayNumber}</span>
+                <div className="text-xs text-gray-500">
+                  <div>{(summary?.hours ?? 0).toFixed(2)} h</div>
+                  <div>{summary?.sessions ?? 0} 件</div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      <DayDrawer date={drawerDate} open={drawerOpen} onClose={closeDrawer} />
+    </section>
+  );
+}

--- a/app/(protected)/dashboard/_components/DayDrawer.tsx
+++ b/app/(protected)/dashboard/_components/DayDrawer.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState, type ReactElement } from 'react';
+
+type DaySessionDetail = {
+  username: string;
+  sitename: string;
+  workdescription: string;
+  clockInAt: string;
+  clockOutAt: string;
+  hours: number;
+  projectName?: string;
+};
+
+type DayDetailResponse = {
+  date: string;
+  sessions: DaySessionDetail[];
+  spreadsheetUrl: string | null;
+};
+
+type DayDrawerProps = {
+  date: string | null;
+  open: boolean;
+  onClose: () => void;
+};
+
+function formatTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat('ja-JP', {
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    weekday: 'short',
+  }).format(date);
+}
+
+function EmptyState(): ReactElement {
+  return (
+    <p className="text-sm text-gray-500">対象日のセッションは登録されていません。</p>
+  );
+}
+
+function LoadingState(): ReactElement {
+  return <div className="h-24 animate-pulse rounded-xl bg-gray-100" />;
+}
+
+function ErrorState({ message, onRetry }: { message: string; onRetry: () => void }): ReactElement {
+  return (
+    <div className="space-y-3">
+      <p className="text-sm font-medium text-red-600">{message}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="rounded-full bg-red-600 px-4 py-2 text-xs font-semibold text-white shadow hover:bg-red-700"
+      >
+        再試行
+      </button>
+    </div>
+  );
+}
+
+export default function DayDrawer({ date, open, onClose }: DayDrawerProps): ReactElement | null {
+  const [detail, setDetail] = useState<DayDetailResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchDetail = useCallback(
+    async (signal?: AbortSignal) => {
+      if (!date) {
+        return;
+      }
+      try {
+        const response = await fetch(`/api/dashboard/day-detail?date=${encodeURIComponent(date)}`, {
+          cache: 'no-store',
+          signal,
+        });
+        if (!response.ok) {
+          throw new Error(`failed with status ${response.status}`);
+        }
+        const json = (await response.json()) as DayDetailResponse;
+        setDetail(json);
+      } catch (err) {
+        if ((err as { name?: string }).name === 'AbortError') {
+          return;
+        }
+        console.error('Failed to fetch day detail', err);
+        setError('日別明細の取得に失敗しました。');
+      }
+    },
+    [date],
+  );
+
+  useEffect(() => {
+    if (!open || !date) {
+      return undefined;
+    }
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    void fetchDetail(controller.signal).finally(() => {
+      setLoading(false);
+    });
+    return () => {
+      controller.abort();
+    };
+  }, [date, fetchDetail, open]);
+
+  const handleRetry = useCallback(() => {
+    if (!date) {
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    void fetchDetail().finally(() => {
+      setLoading(false);
+    });
+  }, [date, fetchDetail]);
+
+  const heading = useMemo(() => (detail?.date ? formatDate(detail.date) : date ? formatDate(date) : ''), [date, detail]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/30 px-4 pb-4 pt-12" role="dialog" aria-modal>
+      <div className="w-full max-w-2xl rounded-t-3xl bg-white p-6 shadow-xl">
+        <div className="mb-4 flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-gray-400">日別明細</p>
+            <h4 className="text-lg font-semibold text-gray-900">{heading}</h4>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full bg-gray-200 px-3 py-1 text-xs font-semibold text-gray-700 hover:bg-gray-300"
+            aria-label="詳細を閉じる"
+          >
+            閉じる
+          </button>
+        </div>
+        {loading && <LoadingState />}
+        {!loading && error && <ErrorState message={error} onRetry={handleRetry} />}
+        {!loading && !error && detail && detail.sessions.length === 0 && <EmptyState />}
+        {!loading && !error && detail && detail.sessions.length > 0 && (
+          <ul className="space-y-4">
+            {detail.sessions.map((session, index) => (
+              <li key={`${session.username}-${session.clockInAt}-${index}`} className="rounded-2xl border border-gray-100 p-4">
+                <div className="flex flex-col gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
+                      {session.username}
+                    </span>
+                    <span className="text-sm text-gray-600">{session.sitename}</span>
+                    {session.projectName && (
+                      <span className="rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-600">{session.projectName}</span>
+                    )}
+                  </div>
+                  <p className="text-sm text-gray-700">{session.workdescription}</p>
+                  <div className="flex flex-wrap items-center gap-3 text-xs text-gray-500">
+                    <span>
+                      IN {formatTime(session.clockInAt)} / OUT {formatTime(session.clockOutAt)}
+                    </span>
+                    <span className="rounded-full bg-gray-100 px-2 py-1 text-xs font-semibold text-gray-700">
+                      {session.hours.toFixed(2)} h
+                    </span>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+        {!loading && !error && detail?.spreadsheetUrl && (
+          <div className="mt-6 text-right">
+            <a
+              href={detail.spreadsheetUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-primary/90"
+            >
+              スプレッドシートを開く
+            </a>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(protected)/dashboard/_components/ProjectsTable.tsx
+++ b/app/(protected)/dashboard/_components/ProjectsTable.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState, type ReactElement } from 'react';
+
+type ProjectStatus = '準備中' | '進行中' | '保留' | '完了';
+
+type ProjectListItem = {
+  projectId: string;
+  name: string;
+  siteName: string | null;
+  status: ProjectStatus | '';
+  startDate: string | null;
+  endDate: string | null;
+  progressPercent: number | null;
+  spreadsheetUrl: string | null;
+};
+
+type ProjectsResponse = {
+  items: ProjectListItem[];
+  total: number;
+};
+
+function formatDate(value: string | null): string {
+  if (!value) return '未設定';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+}
+
+function ProgressBar({ value }: { value: number }): ReactElement {
+  const clamped = Math.max(0, Math.min(100, value));
+  return (
+    <div className="h-2 w-full rounded-full bg-gray-200" aria-hidden>
+      <div className="h-2 rounded-full bg-primary" style={{ width: `${clamped}%` }} />
+    </div>
+  );
+}
+
+type ErrorBannerProps = {
+  message: string;
+  onRetry: () => void;
+};
+
+function ErrorBanner({ message, onRetry }: ErrorBannerProps): ReactElement {
+  return (
+    <div
+      role="alert"
+      className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <p className="font-medium">{message}</p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="rounded-full bg-red-600 px-3 py-1 text-xs font-semibold text-white shadow hover:bg-red-700"
+        >
+          再試行
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function LoadingSkeleton(): ReactElement {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <div key={index} className="h-16 animate-pulse rounded-xl bg-gray-100" />
+      ))}
+    </div>
+  );
+}
+
+export default function ProjectsTable(): ReactElement {
+  const [data, setData] = useState<ProjectsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadProjects = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/dashboard/projects', { cache: 'no-store' });
+      if (!response.ok) {
+        throw new Error(`failed with status ${response.status}`);
+      }
+      const json = (await response.json()) as ProjectsResponse;
+      setData(json);
+    } catch (err) {
+      console.error('Failed to fetch projects', err);
+      setError('案件情報の取得に失敗しました。時間をおいて再度お試しください。');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadProjects();
+  }, [loadProjects]);
+
+  const projects = useMemo(() => data?.items ?? [], [data]);
+
+  return (
+    <section className="rounded-2xl bg-white p-6 shadow-md">
+      <header className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900">案件進捗</h3>
+          <p className="text-sm text-gray-500">登録済みプロジェクトの状況を確認します。</p>
+        </div>
+        <p className="text-sm text-gray-400" aria-live="polite">
+          合計 {data?.total ?? 0} 件
+        </p>
+      </header>
+      {loading && <LoadingSkeleton />}
+      {!loading && error && <ErrorBanner message={error} onRetry={loadProjects} />}
+      {!loading && !error && (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200" role="table">
+            <thead>
+              <tr className="text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+                <th scope="col" className="px-4 py-3">
+                  案件名
+                </th>
+                <th scope="col" className="px-4 py-3">
+                  現場
+                </th>
+                <th scope="col" className="px-4 py-3">
+                  期間
+                </th>
+                <th scope="col" className="px-4 py-3">
+                  進捗
+                </th>
+                <th scope="col" className="px-4 py-3">
+                  状態
+                </th>
+                <th scope="col" className="px-4 py-3 text-right">
+                  リンク
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 text-sm">
+              {projects.map((project) => {
+                const progress = project.progressPercent ?? 0;
+                return (
+                  <tr key={project.projectId} className="hover:bg-gray-50">
+                    <td className="px-4 py-4">
+                      <div className="font-medium text-gray-900">{project.name}</div>
+                      <div className="text-xs text-gray-400">ID: {project.projectId}</div>
+                    </td>
+                    <td className="px-4 py-4 text-gray-700">{project.siteName ?? '未割当'}</td>
+                    <td className="px-4 py-4 text-gray-700">
+                      <div>{formatDate(project.startDate)}</div>
+                      <div className="text-xs text-gray-400">〜 {formatDate(project.endDate)}</div>
+                    </td>
+                    <td className="px-4 py-4">
+                      <div className="flex items-center gap-3">
+                        <ProgressBar value={progress} />
+                        <span className="w-12 text-right tabular-nums text-gray-700">{progress}%</span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-4 text-gray-700">{project.status || '不明'}</td>
+                    <td className="px-4 py-4 text-right">
+                      {project.spreadsheetUrl ? (
+                        <a
+                          href={project.spreadsheetUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center rounded-full bg-primary px-3 py-1 text-xs font-semibold text-white shadow transition hover:bg-primary/90"
+                          aria-label={`${project.name}のスプレッドシートを開く`}
+                        >
+                          開く
+                        </a>
+                      ) : (
+                        <span className="text-xs text-gray-400">未登録</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+              {projects.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="px-4 py-8 text-center text-sm text-gray-500">
+                    表示できる案件がありません。
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,0 +1,85 @@
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import ProjectsTable from './_components/ProjectsTable';
+import CalendarMonth from './_components/CalendarMonth';
+
+const TAB_KEYS = ['projects', 'calendar'] as const;
+
+type DashboardTab = (typeof TAB_KEYS)[number];
+
+type DashboardPageProps = {
+  searchParams: Record<string, string | string[] | undefined>;
+};
+
+function resolveTab(value: string | null | undefined): DashboardTab {
+  if (value === 'calendar') {
+    return 'calendar';
+  }
+  return 'projects';
+}
+
+function resolveNumberParam(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
+export default async function DashboardPage({ searchParams }: DashboardPageProps) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    redirect('/login');
+  }
+
+  const tab = resolveTab(
+    typeof searchParams.tab === 'string' ? searchParams.tab : Array.isArray(searchParams.tab) ? searchParams.tab[0] : null,
+  );
+
+  const resolvedYear = resolveNumberParam(
+    typeof searchParams.year === 'string' ? searchParams.year : Array.isArray(searchParams.year) ? searchParams.year[0] : null,
+  );
+  const resolvedMonth = resolveNumberParam(
+    typeof searchParams.month === 'string' ? searchParams.month : Array.isArray(searchParams.month) ? searchParams.month[0] : null,
+  );
+
+  const today = new Date();
+  const initialYear = resolvedYear ?? today.getFullYear();
+  const initialMonth = resolvedMonth ?? today.getMonth() + 1;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="rounded-2xl bg-white p-4 shadow-md">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-gray-900">ダッシュボード</h2>
+            <p className="text-sm text-gray-500">案件の進捗と稼働状況を一元管理します。</p>
+          </div>
+          <nav className="flex rounded-full bg-gray-100 p-1" aria-label="ダッシュボード切り替えタブ">
+            {TAB_KEYS.map((key) => {
+              const isActive = tab === key;
+              return (
+                <a
+                  key={key}
+                  href={`?tab=${key}${resolvedYear ? `&year=${resolvedYear}` : ''}${resolvedMonth ? `&month=${resolvedMonth}` : ''}`}
+                  className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+                    isActive
+                      ? 'bg-primary text-white shadow'
+                      : 'text-gray-600 hover:bg-white hover:text-gray-900'
+                  }`}
+                  aria-current={isActive ? 'page' : undefined}
+                >
+                  {key === 'projects' ? '案件進捗' : '稼働状況'}
+                </a>
+              );
+            })}
+          </nav>
+        </div>
+      </div>
+
+      {tab === 'projects' ? (
+        <ProjectsTable />
+      ) : (
+        <CalendarMonth initialYear={initialYear} initialMonth={initialMonth} />
+      )}
+    </div>
+  );
+}

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react';
+
+export default function ProtectedLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex w-full flex-col">
+      <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col px-4 pb-12 pt-6">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/app/api/dashboard/calendar/route.ts
+++ b/app/api/dashboard/calendar/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { getSessionsByMonth } from '@/lib/airtable/sessions';
+
+export const runtime = 'nodejs';
+
+const parseInteger = (value: string | null): number | null => {
+  if (!value) return null;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  return parsed;
+};
+
+export async function GET(request: Request) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'UNAUTHORIZED', code: 'UNAUTHORIZED' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const yearParam = parseInteger(searchParams.get('year'));
+    const monthParam = parseInteger(searchParams.get('month'));
+
+    if (!yearParam || !monthParam) {
+      return NextResponse.json({ error: 'MISSING_PARAMS', code: 'MISSING_PARAMS' }, { status: 400 });
+    }
+
+    if (monthParam < 1 || monthParam > 12) {
+      return NextResponse.json({ error: 'INVALID_MONTH', code: 'INVALID_MONTH' }, { status: 400 });
+    }
+
+    const data = await getSessionsByMonth({ year: yearParam, month: monthParam });
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('[dashboard.calendar]', error);
+    return NextResponse.json({ error: 'INTERNAL_ERROR', code: 'INTERNAL_ERROR' }, { status: 500 });
+  }
+}

--- a/app/api/dashboard/day-detail/route.ts
+++ b/app/api/dashboard/day-detail/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { findSpreadsheetUrlForSites } from '@/lib/airtable/projects';
+import { getDaySessions } from '@/lib/airtable/sessions';
+
+export const runtime = 'nodejs';
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+const extractSiteNames = (sessions: { sitename: string }[]): string[] => {
+  const set = new Set<string>();
+  sessions.forEach((session) => {
+    if (session.sitename) {
+      set.add(session.sitename);
+    }
+  });
+  return Array.from(set);
+};
+
+export async function GET(request: Request) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'UNAUTHORIZED', code: 'UNAUTHORIZED' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const date = searchParams.get('date');
+
+    if (!date || !DATE_PATTERN.test(date)) {
+      return NextResponse.json({ error: 'MISSING_DATE', code: 'MISSING_DATE' }, { status: 400 });
+    }
+
+    const detail = await getDaySessions(date);
+    const spreadsheetUrl = await findSpreadsheetUrlForSites(extractSiteNames(detail.sessions));
+
+    return NextResponse.json({ ...detail, spreadsheetUrl: spreadsheetUrl ?? null });
+  } catch (error) {
+    console.error('[dashboard.day-detail]', error);
+    return NextResponse.json({ error: 'INTERNAL_ERROR', code: 'INTERNAL_ERROR' }, { status: 500 });
+  }
+}

--- a/app/api/dashboard/projects/route.ts
+++ b/app/api/dashboard/projects/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { listProjects, type ProjectListResponse } from '@/lib/airtable/projects';
+
+export const runtime = 'nodejs';
+
+type SortParam = 'progress' | 'startDate' | 'endDate';
+
+type OrderParam = 'asc' | 'desc';
+
+const sortMap: Record<SortParam, 'progressPercent' | 'startDate' | 'endDate'> = {
+  progress: 'progressPercent',
+  startDate: 'startDate',
+  endDate: 'endDate',
+};
+
+const isStatus = (value: string | null): value is '準備中' | '進行中' | '保留' | '完了' => {
+  return value === '準備中' || value === '進行中' || value === '保留' || value === '完了';
+};
+
+const parsePositiveInt = (value: string | null): number | null => {
+  if (!value) return null;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return null;
+  }
+  return parsed;
+};
+
+export async function GET(request: Request) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'UNAUTHORIZED', code: 'UNAUTHORIZED' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const search = searchParams.get('search') ?? undefined;
+    const statusParam = searchParams.get('status');
+    const status = isStatus(statusParam) ? statusParam : undefined;
+    const sortParam = (searchParams.get('sort') as SortParam | null) ?? null;
+    const orderParam = (searchParams.get('order') as OrderParam | null) ?? 'desc';
+    const pageParam = parsePositiveInt(searchParams.get('page'));
+    const pageSizeParam = parsePositiveInt(searchParams.get('pageSize'));
+
+    if (searchParams.get('page') && !pageParam) {
+      return NextResponse.json({ error: 'INVALID_PAGE', code: 'INVALID_PAGE' }, { status: 400 });
+    }
+    if (searchParams.get('pageSize') && !pageSizeParam) {
+      return NextResponse.json({ error: 'INVALID_PAGE_SIZE', code: 'INVALID_PAGE_SIZE' }, { status: 400 });
+    }
+
+    const sortBy = sortParam ? sortMap[sortParam] : 'endDate';
+    const order: OrderParam = orderParam === 'asc' ? 'asc' : 'desc';
+
+    const data = (await listProjects({
+      search,
+      status,
+      sortBy,
+      order,
+      page: pageParam ?? undefined,
+      pageSize: pageSizeParam ?? undefined,
+    })) satisfies ProjectListResponse;
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('[dashboard.projects]', error);
+    return NextResponse.json({ error: 'INTERNAL_ERROR', code: 'INTERNAL_ERROR' }, { status: 500 });
+  }
+}

--- a/docs/system-spec.md
+++ b/docs/system-spec.md
@@ -1,0 +1,19 @@
+# システム仕様メモ
+
+## ER図メモ
+- **Projects** テーブルを追加。Sites テーブルと Link で結合し、プロジェクトごとに `projectId`, `name`, `status`, `startDate`, `endDate`, `progressPercent`, `spreadsheetUrl` を保持する。
+- Session テーブルは `year`, `month`, `day`, `username`, `sitename`, `workdescription`, `clockInAt`, `clockOutAt`, `hours` を保持し、Sites 名から代表スプレッドシートURLを導出する。
+
+## API エンドポイント
+### GET `/api/dashboard/projects`
+- クエリ: `search`, `status`, `sort` (`progress`/`startDate`/`endDate`), `order` (`asc`/`desc`), `page`, `pageSize`。
+- レスポンス: `{ items: [{ projectId, name, siteName, status, startDate, endDate, progressPercent, spreadsheetUrl }], total }`。
+
+### GET `/api/dashboard/calendar`
+- クエリ: `year`, `month`。必須。
+- レスポンス: `{ year, month, days: [{ date, hours, sessions }] }`。hours は小数第2位で丸め。
+
+### GET `/api/dashboard/day-detail`
+- クエリ: `date` (YYYY-MM-DD)。必須。
+- レスポンス: `{ date, sessions: [{ username, sitename, workdescription, clockInAt, clockOutAt, hours, projectName? }], spreadsheetUrl }`。
+- `spreadsheetUrl` は Sites をキーに Projects の最新 (endDate 優先) URL を返却。

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,7 @@ const eslintConfig = [
       'out/**',
       'build/**',
       'next-env.d.ts',
+      'tests/dist/**',
     ],
   },
   // Prettierの設定は、他の設定を上書きするため配列の最後に配置します

--- a/lib/airtable/projects.ts
+++ b/lib/airtable/projects.ts
@@ -1,0 +1,221 @@
+import Airtable, { FieldSet } from 'airtable';
+
+if (!process.env.AIRTABLE_API_KEY || !process.env.AIRTABLE_BASE_ID) {
+  throw new Error('Airtable credentials are not configured');
+}
+
+const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(
+  process.env.AIRTABLE_BASE_ID,
+);
+
+const PROJECTS_TABLE = process.env.AIRTABLE_TABLE_PROJECTS || 'Projects';
+const SITES_TABLE = process.env.AIRTABLE_TABLE_SITES || 'Sites';
+
+type ProjectStatus = '準備中' | '進行中' | '保留' | '完了';
+
+interface ProjectFields extends FieldSet {
+  projectId?: string;
+  name?: string;
+  site?: readonly string[];
+  status?: ProjectStatus;
+  startDate?: string;
+  endDate?: string;
+  progressPercent?: number;
+  spreadsheetUrl?: string;
+}
+
+interface SiteFields extends FieldSet {
+  name?: string;
+}
+
+export type ProjectListItem = {
+  projectId: string;
+  name: string;
+  siteName: string | null;
+  status: ProjectStatus | '';
+  startDate: string | null;
+  endDate: string | null;
+  progressPercent: number | null;
+  spreadsheetUrl: string | null;
+};
+
+export type ProjectListResponse = {
+  items: ProjectListItem[];
+  total: number;
+};
+
+type SortKey = 'progressPercent' | 'startDate' | 'endDate';
+
+type SortOrder = 'asc' | 'desc';
+
+type ListOptions = {
+  search?: string;
+  status?: ProjectStatus;
+  sortBy?: SortKey;
+  order?: SortOrder;
+  page?: number;
+  pageSize?: number;
+};
+
+const withRetry = async <T,>(fn: () => Promise<T>, retries = 3, delay = 500): Promise<T> => {
+  try {
+    return await fn();
+  } catch (error) {
+    if (retries <= 0) {
+      throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    return withRetry(fn, retries - 1, delay * 2);
+  }
+};
+
+let projectsCache: Promise<ProjectListItem[]> | null = null;
+
+const fetchSiteNames = async (siteIds: readonly string[] | undefined): Promise<Map<string, string>> => {
+  const names = new Map<string, string>();
+  if (!siteIds || siteIds.length === 0) {
+    return names;
+  }
+  const uniqueIds = Array.from(new Set(siteIds));
+  const chunkSize = 15;
+  for (let i = 0; i < uniqueIds.length; i += chunkSize) {
+    const chunk = uniqueIds.slice(i, i + chunkSize);
+    const formula = `OR(${chunk.map((id) => `RECORD_ID()='${id}'`).join(',')})`;
+    const records = await withRetry(() =>
+      base<SiteFields>(SITES_TABLE)
+        .select({ filterByFormula: formula, maxRecords: chunk.length })
+        .all(),
+    );
+    records.forEach((record) => {
+      if (typeof record.fields.name === 'string') {
+        names.set(record.id, record.fields.name);
+      }
+    });
+  }
+  return names;
+};
+
+const loadProjects = async (): Promise<ProjectListItem[]> => {
+  const records = await withRetry(() =>
+    base<ProjectFields>(PROJECTS_TABLE)
+      .select({
+        pageSize: 100,
+      })
+      .all(),
+  );
+
+  const siteIds = records.flatMap((record) => record.fields.site ?? []);
+  const siteNames = await fetchSiteNames(siteIds);
+
+  return records.map((record) => {
+    const { fields } = record;
+    const linkedSiteId = fields.site?.[0];
+    const progress =
+      typeof fields.progressPercent === 'number'
+        ? Math.round(fields.progressPercent * 100) / 100
+        : typeof fields.progressPercent === 'string'
+          ? Number.parseFloat(fields.progressPercent)
+          : null;
+    return {
+      projectId: fields.projectId ?? record.id,
+      name: fields.name ?? '未設定',
+      siteName: linkedSiteId ? siteNames.get(linkedSiteId) ?? null : null,
+      status: fields.status ?? '',
+      startDate: fields.startDate ?? null,
+      endDate: fields.endDate ?? null,
+      progressPercent: Number.isFinite(progress) ? progress : null,
+      spreadsheetUrl: fields.spreadsheetUrl ?? null,
+    } satisfies ProjectListItem;
+  });
+};
+
+const ensureProjects = () => {
+  if (!projectsCache) {
+    projectsCache = loadProjects().catch((error) => {
+      projectsCache = null;
+      throw error;
+    });
+  }
+  return projectsCache;
+};
+
+const compareValues = (a: ProjectListItem, b: ProjectListItem, sortBy: SortKey, order: SortOrder): number => {
+  const direction = order === 'desc' ? -1 : 1;
+  if (sortBy === 'progressPercent') {
+    const valueA = a.progressPercent ?? 0;
+    const valueB = b.progressPercent ?? 0;
+    if (valueA === valueB) {
+      return a.name.localeCompare(b.name) * direction;
+    }
+    return (valueA - valueB) * direction;
+  }
+  const rawA = sortBy === 'startDate' ? a.startDate : a.endDate;
+  const rawB = sortBy === 'startDate' ? b.startDate : b.endDate;
+  const timeA = rawA ? Date.parse(rawA) : 0;
+  const timeB = rawB ? Date.parse(rawB) : 0;
+  if (timeA === timeB) {
+    return a.name.localeCompare(b.name) * direction;
+  }
+  return (timeA - timeB) * direction;
+};
+
+export const listProjects = async ({
+  search,
+  status,
+  sortBy = 'endDate',
+  order = 'desc',
+  page = 1,
+  pageSize = 20,
+}: ListOptions = {}): Promise<ProjectListResponse> => {
+  const projects = await ensureProjects();
+  const normalizedSearch = search?.toLowerCase().trim();
+
+  const filtered = projects.filter((project) => {
+    if (status && project.status !== status) {
+      return false;
+    }
+    if (normalizedSearch) {
+      const target = `${project.name} ${project.siteName ?? ''}`.toLowerCase();
+      if (!target.includes(normalizedSearch)) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  const sorted = filtered.slice().sort((a, b) => compareValues(a, b, sortBy, order));
+
+  const safePage = Math.max(page, 1);
+  const safePageSize = Math.max(pageSize, 1);
+  const offset = (safePage - 1) * safePageSize;
+  const items = sorted.slice(offset, offset + safePageSize);
+
+  return { items, total: filtered.length };
+};
+
+export const findSpreadsheetUrlForSites = async (siteNames: readonly string[]): Promise<string | null> => {
+  if (!siteNames.length) {
+    return null;
+  }
+  const projects = await ensureProjects();
+  const candidates = projects.filter(
+    (project) => project.siteName && siteNames.includes(project.siteName),
+  );
+  if (candidates.length === 0) {
+    return null;
+  }
+  const sorted = candidates.sort((a, b) => {
+    const timeA = a.endDate ? Date.parse(a.endDate) : 0;
+    const timeB = b.endDate ? Date.parse(b.endDate) : 0;
+    if (timeA === timeB) {
+      return (b.startDate ? Date.parse(b.startDate) : 0) - (a.startDate ? Date.parse(a.startDate) : 0);
+    }
+    return timeB - timeA;
+  });
+  const found = sorted.find((project) => project.spreadsheetUrl);
+  return found?.spreadsheetUrl ?? null;
+};
+
+export const resetProjectsCache = () => {
+  projectsCache = null;
+};

--- a/lib/airtable/sessions.ts
+++ b/lib/airtable/sessions.ts
@@ -1,0 +1,140 @@
+import Airtable, { FieldSet } from 'airtable';
+
+if (!process.env.AIRTABLE_API_KEY || !process.env.AIRTABLE_BASE_ID) {
+  throw new Error('Airtable credentials are not configured');
+}
+
+const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(
+  process.env.AIRTABLE_BASE_ID,
+);
+
+const SESSIONS_TABLE = process.env.AIRTABLE_TABLE_SESSIONS || 'Session';
+
+interface SessionFields extends FieldSet {
+  year?: number;
+  month?: number;
+  day?: number;
+  hours?: number;
+  username?: string;
+  sitename?: string;
+  workdescription?: string;
+  clockInAt?: string;
+  clockOutAt?: string;
+  projectName?: string;
+}
+
+export type SessionSummaryDay = {
+  date: string;
+  hours: number;
+  sessions: number;
+};
+
+export type CalendarSummary = {
+  year: number;
+  month: number;
+  days: SessionSummaryDay[];
+};
+
+export type DaySessionDetail = {
+  username: string;
+  sitename: string;
+  workdescription: string;
+  clockInAt: string;
+  clockOutAt: string;
+  hours: number;
+  projectName?: string;
+};
+
+export type DaySessionsResponse = {
+  date: string;
+  sessions: DaySessionDetail[];
+};
+
+const withRetry = async <T,>(fn: () => Promise<T>, retries = 3, delay = 500): Promise<T> => {
+  try {
+    return await fn();
+  } catch (error) {
+    if (retries <= 0) {
+      throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    return withRetry(fn, retries - 1, delay * 2);
+  }
+};
+
+const toDateString = (year: number, month: number, day: number) =>
+  `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+
+const roundHours = (value: number | undefined): number => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return 0;
+  }
+  return Math.round(value * 100) / 100;
+};
+
+const fetchSessions = async (filterByFormula: string) => {
+  const records = await withRetry(() =>
+    base<SessionFields>(SESSIONS_TABLE)
+      .select({
+        filterByFormula,
+        pageSize: 100,
+      })
+      .all(),
+  );
+  return records;
+};
+
+export const getSessionsByMonth = async ({
+  year,
+  month,
+}: {
+  year: number;
+  month: number;
+}): Promise<CalendarSummary> => {
+  const records = await fetchSessions(`AND({year}=${year},{month}=${month})`);
+  const map = new Map<string, { hours: number; sessions: number }>();
+  records.forEach((record) => {
+    const { fields } = record;
+    const day = typeof fields.day === 'number' ? fields.day : null;
+    if (!day) {
+      return;
+    }
+    const key = toDateString(year, month, day);
+    const entry = map.get(key) ?? { hours: 0, sessions: 0 };
+    entry.hours += roundHours(fields.hours);
+    entry.sessions += 1;
+    map.set(key, entry);
+  });
+
+  const days: SessionSummaryDay[] = Array.from(map.entries())
+    .map(([date, value]) => ({ date, hours: roundHours(value.hours), sessions: value.sessions }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  return { year, month, days };
+};
+
+export const getDaySessions = async (date: string): Promise<DaySessionsResponse> => {
+  const [year, month, day] = date.split('-').map((part) => Number.parseInt(part, 10));
+  if (!year || !month || !day) {
+    throw new Error('Invalid date string');
+  }
+  const records = await fetchSessions(`AND({year}=${year},{month}=${month},{day}=${day})`);
+  const sessions: DaySessionDetail[] = records.map((record) => {
+    const { fields } = record;
+    const hours = roundHours(fields.hours);
+    const detail: DaySessionDetail = {
+      username: fields.username ?? '不明ユーザー',
+      sitename: fields.sitename ?? '未割当',
+      workdescription: fields.workdescription ?? '',
+      clockInAt: fields.clockInAt ?? '',
+      clockOutAt: fields.clockOutAt ?? '',
+      hours,
+    };
+    if (fields.projectName) {
+      detail.projectName = fields.projectName;
+    }
+    return detail;
+  });
+
+  return { date, sessions };
+};

--- a/tests/dashboard-entry.test.mjs
+++ b/tests/dashboard-entry.test.mjs
@@ -1,0 +1,3 @@
+import './dashboard/api.projects.test.mjs';
+import './dashboard/api.calendar.test.mjs';
+import './dashboard/api.day-detail.test.mjs';

--- a/tests/dashboard/api.calendar.test.mjs
+++ b/tests/dashboard/api.calendar.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const routePath = join(__dirname, '../../app/api/dashboard/calendar/route.ts');
+
+test('calendar route declares node runtime', async () => {
+  const content = await readFile(routePath, 'utf8');
+  assert.ok(content.includes("export const runtime = 'nodejs'"));
+});
+
+test('calendar route validates params', async () => {
+  const content = await readFile(routePath, 'utf8');
+  assert.ok(content.includes('MISSING_PARAMS'));
+  assert.ok(content.includes('INVALID_MONTH'));
+});
+
+test('calendar route uses getSessionsByMonth helper', async () => {
+  const content = await readFile(routePath, 'utf8');
+  assert.ok(content.includes('getSessionsByMonth'));
+  assert.ok(content.includes('return NextResponse.json(data)'));
+});

--- a/tests/dashboard/api.day-detail.test.mjs
+++ b/tests/dashboard/api.day-detail.test.mjs
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const routePath = join(__dirname, '../../app/api/dashboard/day-detail/route.ts');
+
+test('day-detail route declares node runtime', async () => {
+  const content = await readFile(routePath, 'utf8');
+  assert.ok(content.includes("export const runtime = 'nodejs'"));
+});
+
+test('day-detail route validates date param', async () => {
+  const content = await readFile(routePath, 'utf8');
+  assert.ok(content.includes('MISSING_DATE'));
+  assert.ok(content.includes('DATE_PATTERN'));
+});
+
+test('day-detail route combines session detail and spreadsheet url', async () => {
+  const content = await readFile(routePath, 'utf8');
+  assert.ok(content.includes('getDaySessions'));
+  assert.ok(content.includes('findSpreadsheetUrlForSites'));
+  assert.ok(content.includes("return NextResponse.json({ ...detail, spreadsheetUrl: spreadsheetUrl ?? null })"));
+});

--- a/tests/dashboard/api.projects.test.mjs
+++ b/tests/dashboard/api.projects.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const routePath = join(__dirname, '../../app/api/dashboard/projects/route.ts');
+
+test('projects route declares node runtime', async () => {
+  const content = await readFile(routePath, 'utf8');
+  assert.ok(content.includes("export const runtime = 'nodejs'"));
+});
+
+test('projects route has pagination validation errors', async () => {
+  const content = await readFile(routePath, 'utf8');
+  assert.ok(content.includes("INVALID_PAGE"));
+  assert.ok(content.includes("INVALID_PAGE_SIZE"));
+});
+
+test('projects route returns items and total', async () => {
+  const content = await readFile(routePath, 'utf8');
+  assert.ok(content.includes('return NextResponse.json(data)'));
+  assert.ok(content.includes('ProjectListResponse'));
+});


### PR DESCRIPTION
## 目的 / 影響範囲 / 触るファイル
- 保護ルート `/dashboard` と各種 API を追加し、案件進捗と稼働状況を 1 画面で参照できるようにしました。
- 新規 UI コンポーネントおよび Airtable 連携ロジックを実装しています。
- `tests/dashboard-entry.test.mjs` は `pnpm test` がサブディレクトリ配下のテストを実行しないための集約用（目的: 新規 API テストを確実に実行 / 理由: 既存スクリプトが `tests/*.test.mjs` 固定 / 配置: tests/dashboard-entry.test.mjs）。

## 変更点
- `/dashboard` ページとタブ UI（案件進捗テーブル / 稼働カレンダー）を追加。
- Airtable から Projects / Session 情報を取得するユーティリティを新設。
- `/api/dashboard/{projects|calendar|day-detail}` を実装し、認証・バリデーション・エラーハンドリングを整備。
- システム仕様書にダッシュボードの ER/API を追記。
- API ルートの存在検証テストを追加し、既存テスト実行フローに組み込み。
- ESLint 設定で `tests/dist` を除外。

## 影響範囲
- ダッシュボード UI 追加により、認証済みユーザーが新ページへ遷移可能。
- Airtable 呼び出し回数が増えるため、レート制限を考慮したリトライ処理を実装済み。
- テスト実行時に新たな検証が走ります。

## ロールバック手順
1. `git revert <commit>` を実施。
2. Vercel へ再デプロイ。

## テスト結果
- `pnpm build`
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68d4bf23347883298b90d1477d5f36b4