### PR TITLE
feat(day-drawer): rename 完了→正常, dark-on-light text, group sessions by user

### DIFF
--- a/app/(protected)/dashboard/_components/DayDetailDrawer.tsx
+++ b/app/(protected)/dashboard/_components/DayDetailDrawer.tsx
@@ -191,7 +191,7 @@ export default function DayDetailDrawer({ date, open, onClose }: DayDetailDrawer
                     {sessionGroups.map((group) => (
                       <div key={group.userName} className="rounded-2xl border border-gray-100 bg-white p-4 shadow-sm sm:p-5">
                         <div className="flex items-center justify-between">
-                          <p className="text-[15px] font-semibold text-gray-900 sm:text-base">{group.userName}</p>
+                          <p className="text-[15px] font-semibold text-gray-900 !text-black sm:text-base">{group.userName}</p>
                         </div>
                         <div className="mt-2 divide-y divide-gray-100">
                           {group.items.map((session, index) => {

--- a/app/(protected)/dashboard/_components/DayDetailDrawer.tsx
+++ b/app/(protected)/dashboard/_components/DayDetailDrawer.tsx
@@ -8,7 +8,12 @@ type SessionRecord = {
   clockInAt: string;
   clockOutAt?: string | null;
   hours?: number | null;
-  status: '完了' | '稼働中';
+  status: '正常' | '稼働中';
+};
+
+type SessionGroup = {
+  userName: string;
+  items: SessionRecord[];
 };
 
 type DayDetailResponse = {
@@ -98,6 +103,22 @@ export default function DayDetailDrawer({ date, open, onClose }: DayDetailDrawer
   }, [open]);
 
   const headerLabel = useMemo(() => formatDateLabel(detail?.date ?? date ?? null), [date, detail?.date]);
+  const sessionGroups = useMemo<SessionGroup[]>(() => {
+    if (!detail?.sessions) {
+      return [];
+    }
+    const grouped = new Map<string, SessionGroup>();
+    for (const session of detail.sessions) {
+      const key = session.userName || '未登録ユーザー';
+      const current = grouped.get(key);
+      if (current) {
+        current.items.push(session);
+      } else {
+        grouped.set(key, { userName: key, items: [session] });
+      }
+    }
+    return Array.from(grouped.values());
+  }, [detail?.sessions]);
 
   if (!open) {
     return null;
@@ -163,37 +184,39 @@ export default function DayDetailDrawer({ date, open, onClose }: DayDetailDrawer
             <div className="space-y-4">
               <section>
                 <h4 className="text-sm font-semibold text-gray-800">セッション概要</h4>
-                {detail.sessions.length === 0 ? (
+                {sessionGroups.length === 0 ? (
                   <p className="mt-2 text-sm text-gray-500">この日にペアリングされたセッションはありません。</p>
                 ) : (
-                  <ul className="mt-3 space-y-3">
-                    {detail.sessions.map((session, index) => {
-                      const statusColor = session.status === '稼働中' ? 'text-orange-600' : 'text-blue-600';
-                      return (
-                        <li
-                          key={`${session.userName}-${session.clockInAt}-${index}`}
-                          className="rounded-2xl border border-gray-100 p-4 shadow-sm sm:p-5"
-                        >
-                          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                            <div>
-                              <p className="text-sm font-semibold text-gray-900">{session.userName}</p>
-                              <p className="text-xs text-gray-500">{session.siteName ?? '現場未設定'}</p>
-                            </div>
-                            <span className={`text-xs font-semibold ${statusColor}`}>{session.status}</span>
-                          </div>
-                          <div className="mt-2 text-sm text-gray-600 sm:text-base">
-                            {session.clockInAt}
-                            {session.clockOutAt ? <span className="ml-1">→ {session.clockOutAt}</span> : null}
-                          </div>
-                          {typeof session.hours === 'number' ? (
-                            <p className="mt-1 text-sm font-medium text-blue-600 sm:text-base">
-                              {session.hours.toFixed(2)}時間
-                            </p>
-                          ) : null}
-                        </li>
-                      );
-                    })}
-                  </ul>
+                  <div className="mt-3 space-y-3">
+                    {sessionGroups.map((group) => (
+                      <div key={group.userName} className="rounded-2xl border border-gray-100 bg-white p-4 shadow-sm sm:p-5">
+                        <div className="flex items-center justify-between">
+                          <p className="text-[15px] font-semibold text-gray-900 sm:text-base">{group.userName}</p>
+                        </div>
+                        <div className="mt-2 divide-y divide-gray-100">
+                          {group.items.map((session, index) => {
+                            const statusClass = session.status === '稼働中' ? 'text-orange-600' : 'text-primary';
+                            return (
+                              <div
+                                key={`${session.userName}-${session.clockInAt}-${index}`}
+                                className="py-2 first:pt-0 last:pb-0"
+                              >
+                                <p className="text-xs text-gray-800 sm:text-sm">{session.siteName ?? '現場未設定'}</p>
+                                <div className="mt-1 flex flex-wrap items-center gap-x-2 text-sm text-gray-900">
+                                  <span>
+                                    {session.clockInAt}
+                                    {session.clockOutAt ? ` → ${session.clockOutAt}` : ''}
+                                  </span>
+                                  {typeof session.hours === 'number' ? <span>（{session.hours}時間）</span> : null}
+                                  <span className={`text-xs sm:text-sm ${statusClass}`}>{session.status}</span>
+                                </div>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
                 )}
               </section>
             </div>

--- a/lib/airtable/logs.ts
+++ b/lib/airtable/logs.ts
@@ -28,7 +28,7 @@ export type CalendarDaySummary = {
   hours: number;
 };
 
-export type SessionStatus = '完了' | '稼働中';
+export type SessionStatus = '正常' | '稼働中';
 
 export type SessionDetail = {
   userName: string;
@@ -258,7 +258,7 @@ function buildSessionDetails(logs: NormalizedLog[]): SessionDetail[] {
       clockInAt: formatJstTime(currentOpen.timestampMs),
       clockOutAt: formatJstTime(log.timestampMs),
       hours: roundHours(durationHours),
-      status: '完了',
+      status: '正常',
     });
     openSessions.set(userKey, null);
   }
@@ -285,7 +285,7 @@ export function summariseMonth(logs: NormalizedLog[]): CalendarDaySummary[] {
   const summaries: CalendarDaySummary[] = [];
   for (const [date, items] of grouped) {
     const sessions = buildSessionDetails(items);
-    const completedSessions = sessions.filter((session) => session.status === '完了');
+    const completedSessions = sessions.filter((session) => session.status === '正常');
     const hours = completedSessions.reduce((total, session) => total + (session.hours ?? 0), 0);
     const sites = Array.from(
       new Set(items.map((item) => item.siteName).filter((name): name is string => Boolean(name))),

--- a/tests/calendar/api.day.test.mjs
+++ b/tests/calendar/api.day.test.mjs
@@ -206,11 +206,17 @@ test('day API returns paired sessions without punches detail', async () => {
   assert.strictEqual(firstSession.clockInAt, '09:00');
   assert.strictEqual(firstSession.clockOutAt, '16:30');
   assert.strictEqual(firstSession.hours, 7.5);
-  assert.strictEqual(firstSession.status, '完了');
+  assert.strictEqual(firstSession.status, '正常');
   const secondSession = body.sessions[1];
   assert.strictEqual(secondSession.userName, 'sato');
   assert.strictEqual(secondSession.hours, 7);
-  assert.strictEqual(secondSession.status, '完了');
+  assert.strictEqual(secondSession.status, '正常');
+  const hasClosed = body.sessions.some((session) => session.status === '正常');
+  assert.ok(hasClosed, 'closed session should exist');
+  const hasOpen = body.sessions.some(
+    (session) => session.status === '稼働中' && session.clockInAt && !session.clockOutAt,
+  );
+  assert.ok(hasOpen, 'open session should be present');
   const openSession = body.sessions.find((session) => session.status === '稼働中');
   assert.ok(openSession, 'open session should be present');
   assert.strictEqual('clockOutAt' in openSession, false);


### PR DESCRIPTION
## 目的／影響範囲／触るファイル
- 目的: 日別ドロワーの可読性を高めつつ、完了ステータスの表記を社内用語「正常」へ合わせる
- 影響範囲: ダッシュボード日別ドロワーのUI表示およびカレンダーAPI経由で提供されるセッション情報
- 触るファイル: lib/airtable/logs.ts, app/(protected)/dashboard/_components/DayDetailDrawer.tsx, tests/calendar/api.day.test.mjs

## 変更点
- Airtable ログ正規化処理でセッション完了ステータスを「正常」にリネーム
- 日別ドロワーでセッションをユーザー単位のカードへ集約し、黒系テキストで可読性を改善
- APIテスト期待値を「正常」表記と複数セッションの検証に追従

## 影響範囲
- ダッシュボードの日次詳細ドロワー表示
- カレンダーAPI `/api/calendar/day`

## ロールバック手順
1. `git revert` で本PRのコミットを取り消す
2. `pnpm build && pnpm test && pnpm lint` を実行し動作確認

## テスト結果
- `pnpm build`
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68d52ef584508329a83a7fdbc4a66a23